### PR TITLE
Improve TypedDict, Enum support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,17 @@
+**v2.0.0b7**  
+1. #14: Improve TypedDict support: 
+   - respect total=False flag on coercion & schema gen 
+   - Proper support for typing.Optional in schema gen.
+2. #21: Properly handle enums:
+   - Downgrade enums to their held values on calls to typic.primitive
+3. Also:
+   - Fix lazy evaluation of value for default factories in settings
+   - Treat subclasses of builtins as builtins in coercer
+
 **v2.0.0b1**  
 This release brings an entirely new annotation resolution engine which
 is backwards-incompatible with v1. The high-level API remains largely
-the same. 
+the same.
 
 New features include:
 1. ``@typic.constrained`` for definining restricted versions of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.0.0b6"
+version = "2.0.0b7"
 description = "Typical: Take Typing Further."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/tests/objects.py
+++ b/tests/objects.py
@@ -178,6 +178,10 @@ class TDict(TypedDict):
     a: int
 
 
+class TDictPartial(TypedDict, total=False):
+    a: int
+
+
 class NTup(typing.NamedTuple):
     a: int
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -46,7 +46,12 @@ def test_typic_objects_schema(obj):
             typic.ObjectSchemaField(
                 description=objects.FromDict.__doc__,
                 title=objects.FromDict.__name__,
-                properties=typic.FrozenDict(foo=typic.StrSchemaField()),
+                properties=typic.FrozenDict(
+                    foo=typic.MultiSchemaField(
+                        title="Foo",
+                        oneOf=(typic.StrSchemaField(), typic.NullSchemaField()),
+                    )
+                ),
                 required=(),
                 additionalProperties=False,
                 definitions=typic.FrozenDict(),
@@ -86,6 +91,17 @@ def test_typic_objects_schema(obj):
                 title=objects.TDict.__name__,
                 properties=typic.FrozenDict(a=typic.IntSchemaField()),
                 required=("a",),
+                additionalProperties=False,
+                definitions=typic.FrozenDict(),
+            ),
+        ),
+        (
+            objects.TDictPartial,
+            typic.ObjectSchemaField(
+                description=objects.TDictPartial.__doc__,
+                title=objects.TDictPartial.__name__,
+                properties=typic.FrozenDict(a=typic.IntSchemaField()),
+                required=(),
                 additionalProperties=False,
                 definitions=typic.FrozenDict(),
             ),
@@ -144,7 +160,12 @@ def test_typic_schema(obj, expected):
             dict(
                 description=objects.FromDict.__doc__,
                 title=objects.FromDict.__name__,
-                properties={"foo": {"type": "string"}},
+                properties={
+                    "foo": {
+                        "oneOf": [{"type": "string"}, {"type": "null"}],
+                        "title": "Foo",
+                    }
+                },
                 required=[],
                 additionalProperties=False,
                 definitions={},

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -38,19 +38,23 @@ def test__resolve_from_env_field():
 
 class Bar:
     data: dict
+    array: list
 
 
 @pytest.mark.parametrize(
-    argnames=("kwargs", "value", "name"),
+    argnames=("kwargs", "environ"),
     argvalues=[
-        ({"prefix": "", "case_sensitive": False, "aliases": {}}, "{}", "data"),
+        (
+            {"prefix": "", "case_sensitive": False, "aliases": {}},
+            {"data": "{}", "array": "[]"},
+        ),
         (
             {"prefix": "OTHER_", "case_sensitive": False, "aliases": {}},
-            "{}",
-            "OTHER_DATA",
+            {"OTHER_DATA": "{}", "OTHER_ARRAY": "[]"},
         ),
     ],
 )
-def test__resolve_from_env_factory(kwargs, value, name):
-    resolved = _resolve_from_env(Bar, **kwargs, environ={name: value})
+def test__resolve_from_env_factory(kwargs, environ):
+    resolved = _resolve_from_env(Bar, **kwargs, environ=environ)
     assert resolved.data.default_factory() == {}
+    assert resolved.array.default_factory() == []

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -38,11 +38,13 @@ from tests.objects import (
     NTup,
     ntup,
     TDict,
+    TDictPartial,
 )
 from typic.api import coerce, typed, resolve, wrap, wrap_cls, constrained
 from typic.checks import isbuiltintype, BUILTIN_TYPES
 from typic.constraints import ConstraintValueError
 from typic.util import safe_eval, resolve_supertype, origin as get_origin, get_args
+from typic.types import NetworkAddress
 
 
 @pytest.mark.parametrize(argnames="obj", argvalues=BUILTIN_TYPES)
@@ -77,6 +79,7 @@ def test_isbuiltintype(obj: typing.Any):
         (NestedFromDict, {"data": {"foo": "bar!"}}),
         (FooNum, "bar"),
         (Data, Data("bar!")),
+        (NetworkAddress, "localhost"),
     ],
 )
 def test_coerce_simple(annotation, value):
@@ -96,6 +99,7 @@ def test_coerce_newtype(annotation, value):
         (TDict, '{"a": "2"}', {"a": 2}),
         (NTup, '{"a": "2"}', NTup(2)),
         (ntup, '{"a": "2"}', ntup("2")),
+        (TDictPartial, "{}", {}),
     ],
 )
 def test_coerce_collection_metas(annotation, value, expected):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -42,11 +42,12 @@ from tests import objects
         (objects.Data(foo="foo"), {"foo": "foo"}),
         (objects.FromDict(), {"foo": None}),
         (decimal.Decimal("1.0"), 1.0),
+        (objects.FooNum.bar, "bar"),
     ],
 )
 def test_primitive(obj, expected):
     primitive = typic.util.primitive(obj)
-    assert primitive == expected
+    assert repr(primitive) == repr(expected)
     assert isinstance(primitive, type(expected))
 
 

--- a/typic/api.py
+++ b/typic/api.py
@@ -363,7 +363,7 @@ def _resolve_from_env(
         if not isinstance(field, dataclasses.Field):
             field = dataclasses.field()
         if use_factory:
-            field.default_factory = lambda: val
+            field.default_factory = lambda x=val: x
             field.default = dataclasses.MISSING
         else:
             field.default = val

--- a/typic/schema/field.py
+++ b/typic/schema/field.py
@@ -38,8 +38,9 @@ __all__ = (
     "BaseSchemaField",
     "BooleanSchemaField",
     "IntSchemaField",
-    "NumberSchemaField",
     "MultiSchemaField",
+    "NumberSchemaField",
+    "NullSchemaField",
     "ObjectSchemaField",
     "ReadOnly",
     "Ref",
@@ -80,6 +81,7 @@ class SchemaType(str, enum.Enum):
     OBJ = "object"
     ARR = "array"
     BOOL = "boolean"
+    NULL = "null"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -213,6 +215,11 @@ class MultiSchemaField(BaseSchemaField):
 
 
 @dataclasses.dataclass(frozen=True, repr=False)
+class NullSchemaField(BaseSchemaField):
+    type = SchemaType.NULL
+
+
+@dataclasses.dataclass(frozen=True, repr=False)
 class StrSchemaField(BaseSchemaField):
     """A JSON Schema Field for the ``string`` type.
 
@@ -323,6 +330,7 @@ SchemaField = Union[
     ArraySchemaField,
     MultiSchemaField,
     UndeclaredSchemaField,
+    NullSchemaField,
 ]
 """A type-alias for the defined JSON Schema Fields."""
 
@@ -381,5 +389,6 @@ SCHEMA_FIELD_FORMATS: frozendict.FrozenDict[type, SchemaField] = frozendict.Froz
         re.Pattern: StrSchemaField(format=StringFormat.RE),  # type: ignore
         ipaddress.IPv4Address: StrSchemaField(format=StringFormat.IPV4),
         ipaddress.IPv6Address: StrSchemaField(format=StringFormat.IPV6),
+        type(None): NullSchemaField(),
     }
 )


### PR DESCRIPTION

#14: Improve TypedDict support:
- respect `total=False` flag on coercion & schema gen
- Proper support for `typing.Optional` in schema gen.

#21: Properly handle enums:
- Downgrade enums to their held values on calls to `typic.primitive`

Also:
- Fix lazy evaluation of value for default factories in settings
- Treat subclasses of builtins as builtins in coercer