### PR TITLE
Bugfixes & Inaccuracies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ python:
   - "3.7"
   - "3.8"
   - "3.8-dev"
-  - "nightly"
+# Commenting out until upstream libraries are fixed for 3.9 breaking changes.
+#  - "nightly"
 
 stages:
   - linting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+**v2.0.0b11**  
+Bugfixes:
+- Fix handling of `typing.Any` in contraints & schema gen.
+
+Also:
+- #25: Remove now-inaccurate statement regarding pydantic in docs.
+
+
 **v2.0.0b10**  
 Bugfixes:
 - Properly handle Unions/MultiConstraints within arrays and dicts

--- a/docs/usage/strict-mode.rst
+++ b/docs/usage/strict-mode.rst
@@ -75,10 +75,6 @@ side-effect of coercion, the line between the two operations is not blurred. In 
 to operate with *validation-first*, you must change the mode of operation. This is not
 the case in other popular libraries.
 
-For instance, ``pydantic`` will coerce a ``float`` to an ``int``, but will raise an
-error if a ``str`` is passed to a field marked as ``datetime``. This behavior can be
-unpredictable and hard to grok.
-
 These are the paths to "validation" which ``typical`` will follow:
 
 Validate-by-Coerce

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.0.0b10"
+version = "2.0.0b11"
 description = "Typical: Take Typing Further."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-from typing import List, Tuple, Set, Union, Mapping, Dict
-
 import pytest
+
+from typing import List, Tuple, Set, Union, Mapping, Dict, Any
 
 import typic
 from typic.schema import (
@@ -32,6 +32,7 @@ def test_typic_objects_schema(obj):
         (set, typic.ArraySchemaField(uniqueItems=True)),
         (frozenset, typic.ArraySchemaField(uniqueItems=True, additionalItems=False)),
         (tuple, typic.ArraySchemaField(additionalItems=False)),
+        (Any, typic.UndeclaredSchemaField()),
         (List[str], typic.ArraySchemaField(items=typic.StrSchemaField())),
         (
             List[objects.LargeInt],

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -466,6 +466,20 @@ def test_enforce_strict_mode():
     coerce.STRICT = False
 
 
+def test_constrained_any():
+    strict_mode()
+
+    @typed
+    @dataclasses.dataclass
+    class Foo:
+        bar: typing.Any
+
+    assert Foo(1).bar == 1
+    assert Foo("bar").bar == "bar"
+
+    coerce.STRICT = False
+
+
 @pytest.mark.parametrize(
     argnames=("anno", "val"),
     argvalues=[

--- a/typic/schema/schema.py
+++ b/typic/schema/schema.py
@@ -139,7 +139,7 @@ class SchemaBuilder:
         use = getattr(anno.origin, "__parent__", anno.origin)
         # If there's not a static annotation, short-circuit the rest of the checks.
         schema: SchemaField
-        if use is anno.EMPTY:
+        if use in {Any, anno.EMPTY}:
             schema = UndeclaredSchemaField()
             self.__cache[anno] = schema
             return schema

--- a/typic/util.py
+++ b/typic/util.py
@@ -35,6 +35,7 @@ __all__ = (
     "safe_eval",
     "origin",
     "get_args",
+    "get_name",
     "resolve_supertype",
     "cached_property",
     "cached_signature",
@@ -180,6 +181,27 @@ def get_args(annotation: Any) -> Tuple[Any, ...]:
     return (
         *(x for x in getattr(annotation, "__args__", ()) if type(x) is not TypeVar),
     )
+
+
+@functools.lru_cache(maxsize=None)
+def get_name(obj: Type) -> str:
+    """Safely retrieve the name of either a standard object or a type annotation.
+
+    Examples
+    --------
+    >>> import typic
+    >>> from typing import Dict, Any
+    >>> T = TypeVar("T")
+    >>> typic.get_name(Dict)
+    'Dict'
+    >>> typic.get_name(Any)
+    'Any'
+    >>> typic.get_name(dict)
+    'dict'
+    """
+    if hasattr(obj, "_name"):
+        return obj._name
+    return obj.__name__
 
 
 @functools.lru_cache(maxsize=None)


### PR DESCRIPTION
- #25: Remove now-inaccurate statement regarding pydantic in docs.
- Fix handling of `typing.Any` in contraints & schema gen.