### PR TITLE
Optimizations and Improvements for Serde Protocol

### DIFF
--- a/benchmark/models/typ.py
+++ b/benchmark/models/typ.py
@@ -59,6 +59,6 @@ class Model:
 
 def validate(data):
     try:
-        return True, Model.transmute(data)
+        return True, Model(**data)
     except (TypeError, ValueError) as err:
         return False, err

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -19,6 +19,8 @@ from tests import objects
     argnames=("obj",), argvalues=[(x,) for x in objects.TYPIC_OBJECTS]
 )
 def test_typic_objects_schema(obj):
+    if hasattr(obj, "resolve"):
+        obj.resolve()
     assert obj.schema() is typic.schema(obj)
 
 

--- a/typic/serde/resolver.py
+++ b/typic/serde/resolver.py
@@ -86,7 +86,11 @@ class Resolver:
         return self.transmute(annotation, value)
 
     def seen(self, t: Type) -> bool:
-        return t in self.__seen or hasattr(t, ORIG_SETTER_NAME)
+        return (
+            t in self.__seen
+            or hasattr(t, ORIG_SETTER_NAME)
+            or not getattr(t, "__delayed__", True)
+        )
 
     def primitive(self, obj: Any) -> Any:
         """A method for converting an object to its primitive equivalent.

--- a/typic/util.py
+++ b/typic/util.py
@@ -19,11 +19,13 @@ from typing import (
     TypeVar,
     Callable,
     get_type_hints,
+    Union,
 )
 
 import typic.checks as checks
 
 __all__ = (
+    "cached_issubclass",
     "cached_property",
     "cached_signature",
     "cached_type_hints",
@@ -366,7 +368,7 @@ def cached_signature(obj: Callable) -> inspect.Signature:
     Building the function signature is notoriously slow, but we can be safe that the
     signature won't change at runtime, so we cache the result.
 
-    We also provide a little magic so that we can introspect the new :py:class:`TypedDict`
+    We also provide a little magic so that we can introspect :py:class:`TypedDict`
     """
     return (
         typed_dict_signature(obj) if checks.istypeddict(obj) else inspect.signature(obj)
@@ -380,6 +382,12 @@ def cached_type_hints(obj: Callable) -> dict:
     We don't want to go through the process of resolving type-hints every time.
     """
     return get_type_hints(obj)
+
+
+@functools.lru_cache(maxsize=None)
+def cached_issubclass(st: Type, t: Union[Type, Tuple[Type, ...]]) -> bool:
+    """A cached result of :py:func:`issubclass`."""
+    return issubclass(st, t)
 
 
 def typed_dict_signature(obj: Callable) -> inspect.Signature:


### PR DESCRIPTION
Optimizations:
- api.py: Wrapper for typed classes now produces faster setattr method
- api.py: Delayed typed classes are now slightly slower on init, but still within an optimal range.
- resolver.py: Fix checks for `Resolver.seen`
- des.py: Use `Annotation.resolved` when checking if class has been "seen"
- des.py: Use cached subclass check in lieu of instance check.

Extras:
- Add `validate` method to wrapped classes.