### PR TITLE
Bugfixes:

### DIFF
--- a/typic/api.py
+++ b/typic/api.py
@@ -579,7 +579,7 @@ def _resolve_from_env(
     for k in env.keys() & names:
         name = aliases.get(k, k)
         attr, typ = fields[name]
-        val = coerce(env[k], typ)
+        val = transmute(typ, env[k])
         use_factory = not ishashable(val)
         field = getattr(cls, attr, sentinel)
         if not isinstance(field, dataclasses.Field):

--- a/typic/checks.py
+++ b/typic/checks.py
@@ -270,7 +270,7 @@ def isdatetype(obj: Type[ObjectT]) -> bool:
     >>> typic.isdatetype(NewType("Foo", datetime.datetime))
     True
     """
-    return util.origin(obj) in {datetime.datetime, datetime.date}
+    return _issubclass(util.origin(obj), (datetime.datetime, datetime.date))
 
 
 _COLLECTIONS = {list, set, tuple, frozenset, dict, str, bytes}


### PR DESCRIPTION
- Fix handling of datetime subclasses.
- Use `transmute` internally instead of `coerce`
- Add `py.typed` to help mypy out.