### PR TITLE
Add exception ModuleNotFoundError to ext.json

### DIFF
--- a/typic/ext/json.py
+++ b/typic/ext/json.py
@@ -11,7 +11,7 @@ try:
     dumps = ujson.dumps  # type: ignore
     loads = ujson.loads
 
-except ImportError:  # pragma: nocover
+except (ImportError, ModuleNotFoundError):  # pragma: nocover
     import json
     from typic.serde.resolver import resolver
 


### PR DESCRIPTION
If ujson is not present get ModuleNotFoundError, have to catch this. 