### PR TITLE
Bugfix: Bind directly to existing class definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.0.3"
+version = "2.0.4"
 description = "Typical: Python's Typing Toolkit."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/tests/objects.py
+++ b/tests/objects.py
@@ -97,6 +97,17 @@ class SubTypic(Typic):
     sub: str
 
 
+@typic.klass
+class Base:
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+
+@typic.klass
+class SuperBase(Base):
+    super: str
+
+
 @typic.klass(frozen=True)
 class FrozenTypic:
     var: str

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -52,6 +52,7 @@ from tests.objects import (
     Typical,
     get_id,
     SubTypic,
+    SuperBase,
 )
 from typic.api import (
     transmute,
@@ -125,6 +126,7 @@ def test_isbuiltintype(obj: typing.Any):
         (Nested, NestedFromDict(Data("bar!")), Nested(Data("bar!"))),
         (Nested, NestedFromDict(Data("bar!")), Nested(Data("bar!"))),
         (SubTypic, {"var": "var", "sub": b"sub"}, SubTypic("var", "sub")),  # type: ignore
+        (SuperBase, {"super": b"base!"}, SuperBase("base!")),  # type: ignore
     ],
     ids=get_id,
 )


### PR DESCRIPTION
Creating a new class definition broke magic `super()` calls. Previously, this wasn't an issue because the new class contained the old class in its MRO.

This takes a leaf out of `dataclasses` implementation and just attaches everything directly to the existing class definition.

This resolves #60 