### PR TITLE
Improvement: New setter implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.0.4"
+version = "2.0.5"
 description = "Typical: Python's Typing Toolkit."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/tests/objects.py
+++ b/tests/objects.py
@@ -107,6 +107,9 @@ class Base:
 class SuperBase(Base):
     super: str
 
+    def __setattr__(self, key, value):
+        super().__setattr__(key, value)
+
 
 @typic.klass(frozen=True)
 class FrozenTypic:


### PR DESCRIPTION
The previous implementation of our setattr interception caused infinite recursion if the pre-defined setattr on the target class contained a call to `super()`.

Previous attempts to use a decorator to solve this problem were discarded, as they caused significant increases (~+10%) in operation time. This implementation resolves those slowdowns with some bytecode-hacking (namely, localizing target variables within the closure of the wrapper function).

This resolves #62 