### PR TITLE
Improvement: Allow for unknown fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.0.5"
+version = "2.0.6"
 description = "Typical: Python's Typing Toolkit."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/tests/objects.py
+++ b/tests/objects.py
@@ -269,6 +269,20 @@ class Typical:
     id: typing.Optional[typic.ReadOnly[int]] = None
 
 
+@typic.klass
+class Source:
+    test: typing.Optional[str] = typic.field(init=False)
+    field_to_ignore: str = "Ignore me"
+
+    def __post_init__(self):
+        self.test = "Something"
+
+
+@typic.klass
+class Dest:
+    test: typing.Optional[str] = None
+
+
 TYPIC_OBJECTS = [
     Typic,
     Inherited,

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -53,6 +53,8 @@ from tests.objects import (
     get_id,
     SubTypic,
     SuperBase,
+    Source,
+    Dest,
 )
 from typic.api import (
     transmute,
@@ -117,6 +119,7 @@ def test_isbuiltintype(obj: typing.Any):
         (FromDict, {"foo": "bar!"}, FromDict("bar!")),
         (Data, {"foo": "bar!"}, Data("bar!")),
         (Nested, {"data": {"foo": "bar!"}}, Nested(Data("bar!"))),
+        (Nested, {"data": {"foo": "bar!", "something": "else"}}, Nested(Data("bar!"))),
         (NestedFromDict, {"data": {"foo": "bar!"}}, NestedFromDict(Data("bar!"))),
         (FooNum, "bar", FooNum.bar),
         (Data, Data("bar!"), Data("bar!"),),
@@ -127,6 +130,7 @@ def test_isbuiltintype(obj: typing.Any):
         (Nested, NestedFromDict(Data("bar!")), Nested(Data("bar!"))),
         (SubTypic, {"var": "var", "sub": b"sub"}, SubTypic("var", "sub")),  # type: ignore
         (SuperBase, {"super": b"base!"}, SuperBase("base!")),  # type: ignore
+        (Dest, Source(), Dest(Source().test)),  # type: ignore
     ],
     ids=get_id,
 )

--- a/typic/serde/des.py
+++ b/typic/serde/des.py
@@ -326,10 +326,11 @@ class DesFactory:
         self._add_subclass_check(func, anno_name)
         self._add_eval(func)
         with func.b(f"if issubclass({self.VTYPE}, Mapping):", Mapping=Mapping) as b:
-            if annotation.serde.fields_in != annotation.serde.fields_out:
-                x = "fields_in[x]"
-                y = f"{self.VNAME}[x]"
-                b.l(
+            x = "fields_in[x]"
+            y = f"{self.VNAME}[x]"
+            b.l(f"intersection = fields_in.keys() & {self.VNAME}.keys()")
+            with b.b("if intersection:") as nb:
+                nb.l(
                     f"{self.VNAME} = "
                     f"{{{x}: {y} for x in fields_in.keys() & {self.VNAME}.keys()}}"
                 )


### PR DESCRIPTION
Previously, we only allowed for unknown fields with primitive data when the fields_out & fields_in for an object didn't match.

Additionally, we didn't allow for translation from a source with a small signature, but matching fields.

These are now supported.

This resolves #64 