### PR TITLE
Bugfix: Collision in translator for classes with the same name

### DIFF
--- a/tests/module/index.py
+++ b/tests/module/index.py
@@ -1,0 +1,9 @@
+import typic
+
+
+@typic.klass
+class MyClass:
+    field: int
+
+    def __post_init__(self):
+        print("index.py: MyClass is being constructed")

--- a/tests/module/other.py
+++ b/tests/module/other.py
@@ -1,0 +1,14 @@
+import typic
+
+
+@typic.klass
+class MyClass:
+    field: int
+
+    def __post_init__(self):
+        print("other.py: MyClass is being constructed")
+
+
+def factory():
+    val = MyClass(field=1)
+    return val

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -56,6 +56,8 @@ from tests.objects import (
     Source,
     Dest,
 )
+from tests.module.index import MyClass
+from tests.module.other import factory
 from typic.api import (
     transmute,
     typed,
@@ -131,6 +133,7 @@ def test_isbuiltintype(obj: typing.Any):
         (SubTypic, {"var": "var", "sub": b"sub"}, SubTypic("var", "sub")),  # type: ignore
         (SuperBase, {"super": b"base!"}, SuperBase("base!")),  # type: ignore
         (Dest, Source(), Dest(Source().test)),  # type: ignore
+        (MyClass, factory(), MyClass(1)),
     ],
     ids=get_id,
 )

--- a/typic/serde/des.py
+++ b/typic/serde/des.py
@@ -398,7 +398,6 @@ class DesFactory:
                         self._build_generic_des(func, anno_name, annotation)
                 func.l(f"{gen.Keyword.RET} {self.VNAME}")
         deserializer = main.compile(ns=ns, name=func_name)
-        self.__DES_CACHE[func_name] = deserializer
         return deserializer
 
     def _check_varargs(

--- a/typic/util.py
+++ b/typic/util.py
@@ -214,6 +214,11 @@ def get_name(obj: Type) -> str:
 
 
 @functools.lru_cache(maxsize=None)
+def get_unique_name(obj: Type) -> str:
+    return f"{get_name(obj)}_{id(obj)}".replace("-", "_")
+
+
+@functools.lru_cache(maxsize=None)
 def resolve_supertype(annotation: Type[Any]) -> Any:
     """Get the highest-order supertype for a NewType.
 


### PR DESCRIPTION
When generating the translator for two classes, we weren't getting a guaranteed unique name -- _Not Good_ :tm:

This resolves #66 