### PR TITLE
Improvement: Improve support for arbitrary types in @typic.klass

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -481,6 +481,14 @@ version = "1.3.5"
 
 [[package]]
 category = "dev"
+description = "NumPy is the fundamental package for array computing with Python."
+name = "numpy"
+optional = false
+python-versions = ">=3.5"
+version = "1.18.3"
+
+[[package]]
+category = "dev"
 description = "Core utilities for Python packages"
 name = "packaging"
 optional = false
@@ -490,6 +498,22 @@ version = "20.3"
 [package.dependencies]
 pyparsing = ">=2.0.2"
 six = "*"
+
+[[package]]
+category = "dev"
+description = "Powerful data structures for data analysis, time series, and statistics"
+name = "pandas"
+optional = false
+python-versions = ">=3.6.1"
+version = "1.0.3"
+
+[package.dependencies]
+numpy = ">=1.13.3"
+python-dateutil = ">=2.6.1"
+pytz = ">=2017.2"
+
+[package.extras]
+test = ["pytest (>=4.0.2)", "pytest-xdist", "hypothesis (>=3.58)"]
 
 [[package]]
 category = "dev"
@@ -923,7 +947,7 @@ json = ["ujson"]
 schema = ["fastjsonschema"]
 
 [metadata]
-content-hash = "1be5858434a69952639102da6e511e74d250eaf150d3b20945fe06e8eaafe754"
+content-hash = "874abb5e86de1c050d7acdab3ede75b1b115000ae88d3cf2a117a3653fb8c44a"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -1158,9 +1182,50 @@ nltk = [
 nodeenv = [
     {file = "nodeenv-1.3.5-py2.py3-none-any.whl", hash = "sha256:5b2438f2e42af54ca968dd1b374d14a1194848955187b0e5e4be1f73813a5212"},
 ]
+numpy = [
+    {file = "numpy-1.18.3-cp35-cp35m-macosx_10_9_intel.whl", hash = "sha256:a6bc9432c2640b008d5f29bad737714eb3e14bb8854878eacf3d7955c4e91c36"},
+    {file = "numpy-1.18.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:48e15612a8357393d176638c8f68a19273676877caea983f8baf188bad430379"},
+    {file = "numpy-1.18.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:eb2286249ebfe8fcb5b425e5ec77e4736d53ee56d3ad296f8947f67150f495e3"},
+    {file = "numpy-1.18.3-cp35-cp35m-win32.whl", hash = "sha256:1e37626bcb8895c4b3873fcfd54e9bfc5ffec8d0f525651d6985fcc5c6b6003c"},
+    {file = "numpy-1.18.3-cp35-cp35m-win_amd64.whl", hash = "sha256:163c78c04f47f26ca1b21068cea25ed7c5ecafe5f5ab2ea4895656a750582b56"},
+    {file = "numpy-1.18.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:3d9e1554cd9b5999070c467b18e5ae3ebd7369f02706a8850816f576a954295f"},
+    {file = "numpy-1.18.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:40c24960cd5cec55222963f255858a1c47c6fa50a65a5b03fd7de75e3700eaaa"},
+    {file = "numpy-1.18.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:a551d8cc267c634774830086da42e4ba157fa41dd3b93982bc9501b284b0c689"},
+    {file = "numpy-1.18.3-cp36-cp36m-win32.whl", hash = "sha256:0aa2b318cf81eb1693fcfcbb8007e95e231d7e1aa24288137f3b19905736c3ee"},
+    {file = "numpy-1.18.3-cp36-cp36m-win_amd64.whl", hash = "sha256:a41f303b3f9157a31ce7203e3ca757a0c40c96669e72d9b6ee1bce8507638970"},
+    {file = "numpy-1.18.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e607b8cdc2ae5d5a63cd1bec30a15b5ed583ac6a39f04b7ba0f03fcfbf29c05b"},
+    {file = "numpy-1.18.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:fdee7540d12519865b423af411bd60ddb513d2eb2cd921149b732854995bbf8b"},
+    {file = "numpy-1.18.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:6725d2797c65598778409aba8cd67077bb089d5b7d3d87c2719b206dc84ec05e"},
+    {file = "numpy-1.18.3-cp37-cp37m-win32.whl", hash = "sha256:4847f0c993298b82fad809ea2916d857d0073dc17b0510fbbced663b3265929d"},
+    {file = "numpy-1.18.3-cp37-cp37m-win_amd64.whl", hash = "sha256:46f404314dbec78cb342904f9596f25f9b16e7cf304030f1339e553c8e77f51c"},
+    {file = "numpy-1.18.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:264fd15590b3f02a1fbc095e7e1f37cdac698ff3829e12ffdcffdce3772f9d44"},
+    {file = "numpy-1.18.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e94a39d5c40fffe7696009dbd11bc14a349b377e03a384ed011e03d698787dd3"},
+    {file = "numpy-1.18.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a4305564e93f5c4584f6758149fd446df39fd1e0a8c89ca0deb3cce56106a027"},
+    {file = "numpy-1.18.3-cp38-cp38-win32.whl", hash = "sha256:99f0ba97e369f02a21bb95faa3a0de55991fd5f0ece2e30a9e2eaebeac238921"},
+    {file = "numpy-1.18.3-cp38-cp38-win_amd64.whl", hash = "sha256:c60175d011a2e551a2f74c84e21e7c982489b96b6a5e4b030ecdeacf2914da68"},
+    {file = "numpy-1.18.3.zip", hash = "sha256:e46e2384209c91996d5ec16744234d1c906ab79a701ce1a26155c9ec890b8dc8"},
+]
 packaging = [
     {file = "packaging-20.3-py2.py3-none-any.whl", hash = "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"},
     {file = "packaging-20.3.tar.gz", hash = "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3"},
+]
+pandas = [
+    {file = "pandas-1.0.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d234bcf669e8b4d6cbcd99e3ce7a8918414520aeb113e2a81aeb02d0a533d7f7"},
+    {file = "pandas-1.0.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:ca84a44cf727f211752e91eab2d1c6c1ab0f0540d5636a8382a3af428542826e"},
+    {file = "pandas-1.0.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1fa4bae1a6784aa550a1c9e168422798104a85bf9c77a1063ea77ee6f8452e3a"},
+    {file = "pandas-1.0.3-cp36-cp36m-win32.whl", hash = "sha256:863c3e4b7ae550749a0bb77fa22e601a36df9d2905afef34a6965bed092ba9e5"},
+    {file = "pandas-1.0.3-cp36-cp36m-win_amd64.whl", hash = "sha256:a210c91a02ec5ff05617a298ad6f137b9f6f5771bf31f2d6b6367d7f71486639"},
+    {file = "pandas-1.0.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:11c7cb654cd3a0e9c54d81761b5920cdc86b373510d829461d8f2ed6d5905266"},
+    {file = "pandas-1.0.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6597df07ea361231e60c00692d8a8099b519ed741c04e65821e632bc9ccb924c"},
+    {file = "pandas-1.0.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:743bba36e99d4440403beb45a6f4f3a667c090c00394c176092b0b910666189b"},
+    {file = "pandas-1.0.3-cp37-cp37m-win32.whl", hash = "sha256:07c1b58936b80eafdfe694ce964ac21567b80a48d972879a359b3ebb2ea76835"},
+    {file = "pandas-1.0.3-cp37-cp37m-win_amd64.whl", hash = "sha256:12f492dd840e9db1688126216706aa2d1fcd3f4df68a195f9479272d50054645"},
+    {file = "pandas-1.0.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0ebe327fb088df4d06145227a4aa0998e4f80a9e6aed4b61c1f303bdfdf7c722"},
+    {file = "pandas-1.0.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:858a0d890d957ae62338624e4aeaf1de436dba2c2c0772570a686eaca8b4fc85"},
+    {file = "pandas-1.0.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:387dc7b3c0424327fe3218f81e05fc27832772a5dffbed385013161be58df90b"},
+    {file = "pandas-1.0.3-cp38-cp38-win32.whl", hash = "sha256:167a1315367cea6ec6a5e11e791d9604f8e03f95b57ad227409de35cf850c9c5"},
+    {file = "pandas-1.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:1a7c56f1df8d5ad8571fa251b864231f26b47b59cbe41aa5c0983d17dbb7a8e4"},
+    {file = "pandas-1.0.3.tar.gz", hash = "sha256:32f42e322fb903d0e189a4c10b75ba70d90958cc4f66a1781ed027f1a1d14586"},
 ]
 pathspec = [
     {file = "pathspec-0.7.0-py2.py3-none-any.whl", hash = "sha256:163b0632d4e31cef212976cf57b43d9fd6b0bac6e67c26015d611a647d5e7424"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.0.10"
+version = "2.0.11"
 description = "Typical: Python's Typing Toolkit."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"
@@ -56,6 +56,7 @@ mkdocstrings = "^0.9.1"
 pymdown-extensions = "^6.3"
 fontawesome-markdown = "^0.2.6"
 mkdocs-awesome-pages-plugin = "^2.2.1"
+pandas = "^1.0.3"
 
 [tool.poetry.extras]
 schema = ["fastjsonschema"]

--- a/tests/objects.py
+++ b/tests/objects.py
@@ -11,6 +11,7 @@ except ImportError:
 
 import inflection
 import typic
+import pandas
 import pydantic
 import sqlalchemy
 from sqlalchemy.ext.declarative import declarative_base
@@ -281,6 +282,11 @@ class Source:
 @typic.klass
 class Dest:
     test: typing.Optional[str] = None
+
+
+@typic.klass
+class DFClass:
+    df: pandas.DataFrame = None
 
 
 TYPIC_OBJECTS = [

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -6,6 +6,7 @@ import typing
 from collections import defaultdict
 from operator import attrgetter
 
+import pandas
 import pendulum
 import pytest
 
@@ -139,6 +140,24 @@ def test_transmute_newtype(annotation, value):
 def test_transmute_collection_metas(annotation, value, expected):
     transmuted = transmute(annotation, value)
     assert transmuted == expected
+
+
+@pytest.mark.parametrize(
+    argnames=("annotation", "value", "expected"),
+    argvalues=[
+        (pandas.DataFrame, {}, pandas.DataFrame()),
+        (pandas.Series, [], pandas.Series()),
+        (objects.DFClass, {}, pandas.DataFrame()),
+        (objects.DFClass, None, None),
+    ],
+)
+def test_transmute_pandas(annotation, value, expected):
+    if annotation is objects.DFClass:
+        transmuted = objects.DFClass(value).df
+    else:
+        transmuted = transmute(annotation, value)
+        assert isinstance(transmuted, annotation)
+    assert transmuted == expected if expected is None else expected.equals(transmuted)
 
 
 def test_default_none():
@@ -357,6 +376,7 @@ def test_eval_invalid():
     argvalues=[
         (typed(objects.Data)("foo"), "foo", 1, str),
         (typed(objects.NoParams)(), "var", 1, str),
+        (objects.DFClass(), "df", {}, pandas.DataFrame),
     ],
     ids=objects.get_id,
 )

--- a/typic/api.py
+++ b/typic/api.py
@@ -486,7 +486,7 @@ def constrained(
     >>> ShortStr('waytoomanycharacters')
     Traceback (most recent call last):
     ...
-    typic.constraints.error.ConstraintValueError: Given value <'waytoomanycharacters'> fails constraints: (type=str, nullable=False, coerce=False, max_length=10)
+    typic.constraints.error.ConstraintValueError: Given value <'waytoomanycharacters'> fails constraints: (type='str', nullable=False, coerce=False, max_length=10)
     >>> @typic.constrained(values=ShortStr, max_items=2)
     ... class SmallMap(dict):
     ...     '''A small map that only allows short strings.'''

--- a/typic/constraints/common.py
+++ b/typic/constraints/common.py
@@ -59,8 +59,11 @@ class __AbstractConstraints(abc.ABC):
 
     @util.cached_property
     def __str(self) -> str:
-        fields = [f"type={self.type_name}"]
+        fields = [f"type={self.type_name!r}"]
         for f in dataclasses.fields(self):
+            if f.name == "type":
+                continue
+
             val = getattr(self, f.name)
             if (val or val in {False, 0}) and f.repr:
                 fields.append(f"{f.name}={val}")
@@ -98,7 +101,11 @@ class __AbstractConstraints(abc.ABC):
             An error inheriting from :py:class:`SyntaxError` indicating the constraint
             configuration is invalid.
         """
-        valid, value = self.validator(value)
+        try:
+            valid, value = self.validator(value)
+        except AttributeError:
+            valid, value = False, value
+
         if not valid:
             field = f"{field}:" if field else "Given"
             raise ConstraintValueError(

--- a/typic/ext/schema/schema.py
+++ b/typic/ext/schema/schema.py
@@ -199,7 +199,16 @@ class SchemaBuilder:
                 self._handle_array(anno, constraints)
             schema = dataclasses.replace(base, **constraints)
         else:
-            schema = self.build_schema(use, name=self.defname(use, name=name))
+            try:
+                schema = self.build_schema(use, name=self.defname(use, name=name))
+            except (ValueError, TypeError):
+                schema = UndeclaredSchemaField(
+                    enum=enum_,
+                    title=self.defname(use, name=name),
+                    default=default,
+                    readOnly=ro,
+                    writeOnly=wo,
+                )
 
         self.__cache[anno] = schema
         return schema

--- a/typic/serde/binder.py
+++ b/typic/serde/binder.py
@@ -321,7 +321,7 @@ class Binder:
         >>> typic.bind(add, 1, 3.0, strict=True)
         Traceback (most recent call last):
             ...
-        typic.constraints.error.ConstraintValueError: Given value <3.0> fails constraints: (type=int, nullable=False, coerce=False)
+        typic.constraints.error.ConstraintValueError: Given value <3.0> fails constraints: (type='int', nullable=False, coerce=False)
         """
         return self._bind_input(
             obj=obj,

--- a/typic/serde/des.py
+++ b/typic/serde/des.py
@@ -117,7 +117,14 @@ class DesFactory:
         if annotation.optional:
             _checks.append(f"{self.VNAME} is None")
         if annotation.has_default:
-            _checks.append(f"{self.VNAME} == __default")
+            if hasattr(annotation.origin, "equals"):
+                _checks.append(
+                    f"({self.VNAME}.equals(__default) "
+                    f"if hasattr({self.VNAME}, 'equals') "
+                    f"else {self.VNAME} == __default)"
+                )
+            else:
+                _checks.append(f"{self.VNAME} == __default")
             _ctx["__default"] = annotation.parameter.default
         if _checks:
             check = " or ".join(_checks)

--- a/typic/util.py
+++ b/typic/util.py
@@ -210,7 +210,7 @@ def get_name(obj: Type) -> str:
     >>> typic.get_name(dict)
     'dict'
     """
-    if hasattr(obj, "_name"):
+    if hasattr(obj, "_name") and not hasattr(obj, "__name__"):
         return obj._name
     return obj.__name__
 


### PR DESCRIPTION
Certain advanced arbitrary types are properly supported in our SerDes protocol, but fail when attached to a class definition. This resolves those issues and adds tests using the `pandas` library.

This resolves #75 