### PR TITLE
Optional Mappings Fail to Compile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.0.13"
+version = "2.0.14"
 description = "Typical: Python's Typing Toolkit."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -279,6 +279,41 @@ def test_transmute_mapping_subscripted(annotation, value):
     assert all(isinstance(x, get_origin(value_arg)) for x in transmuted.values())
 
 
+@pytest.mark.parametrize(
+    argnames=("annotation", "value", "expected"),
+    argvalues=[
+        (typing.Optional[typing.List[int]], '["1"]', [1]),
+        (typing.Optional[typing.List[int]], None, None),
+        (typing.List[typing.Optional[int]], [None], [None]),
+        (typing.List[typing.Optional[int]], ["1"], [1]),
+        (typing.List[typing.Optional[Strict[int]]], [1], [1]),
+        (typing.List[typing.Optional[Strict[int]]], [None], [None]),
+        (typing.Optional[typing.Mapping[str, int]], '{"foo":"1"}', {"foo": 1}),
+        (typing.Optional[typing.Mapping[str, int]], None, None),
+        (
+            typing.Mapping[typing.Optional[str], typing.Optional[int]],
+            '{"foo":null}',
+            {"foo": None},
+        ),
+        (
+            typing.Mapping[typing.Optional[str], typing.Optional[int]],
+            "{None:None}",
+            {None: None},
+        ),
+        (
+            typing.Mapping[typing.Optional[str], typing.Optional[int]],
+            "{None:1}",
+            {None: 1},
+        ),
+        (typing.Mapping[typing.Optional[str], typing.Optional[int]], "{1:1}", {"1": 1}),
+    ],
+    ids=objects.get_id,
+)
+def test_transmute_optional(annotation, value, expected):
+    transmuted = transmute(annotation, value)
+    assert transmuted == expected
+
+
 def test_transmute_nested_sequence():
     transmuted = transmute(objects.NestedSeq, {"datum": [{"foo": "bar"}]})
     assert isinstance(transmuted, objects.NestedSeq)

--- a/typic/serde/common.py
+++ b/typic/serde/common.py
@@ -160,6 +160,10 @@ class Annotation:
         """What types are subscripted to this annotation, if any."""
         return util.get_args(self.resolved)
 
+    @property
+    def resolved_origin(self) -> Type[ObjectT]:
+        return util.origin(self.resolved)
+
     def translator(self, target: Type[_T]) -> TranslatorT:
         """A factory for translating from this type to another."""
         t = translator.factory(self, target)

--- a/typic/serde/ser.py
+++ b/typic/serde/ser.py
@@ -49,7 +49,7 @@ KVPairT = Tuple[KT, VT]
 
 
 def make_class_serdict(annotation: "Annotation", fields: Mapping[str, SerializerT]):
-    name = f"{util.get_name(annotation.origin)}SerDict"
+    name = f"{util.get_name(annotation.resolved_origin)}SerDict"
     bases = (ClassFieldSerDict,)
     getters = annotation.serde.fields_getters
     if annotation.serde.fields_out:
@@ -133,7 +133,7 @@ class ClassFieldSerDict(dict):
 
 
 def make_kv_serdict(annotation: "Annotation", kser: SerializerT, vser: SerializerT):
-    name = f"{util.get_name(annotation.origin)}KVSerDict"
+    name = f"{util.get_name(annotation.resolved_origin)}KVSerDict"
     bases = (KVSerDict,)
     ns = dict(
         lazy=False,
@@ -191,7 +191,7 @@ class KVSerDict(dict):
 
 
 def make_serlist(annotation: "Annotation", serializer: SerializerT):
-    name = f"{util.get_name(annotation.origin)}SerList"
+    name = f"{util.get_name(annotation.resolved_origin)}SerList"
     bases = (SerList,)
     ns = dict(
         lazy=False,


### PR DESCRIPTION
This fixes a regression in compiling mapping deserializers which was introduced when adding support for `defaultdict`, which caused optional mappings to fail to compile.

This resolves #83 