### PR TITLE
Fix nested validation of Path-types and other magic subclasses in Unions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.0.14"
+version = "2.0.15"
 description = "Typical: Python's Typing Toolkit."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -673,7 +673,12 @@ def test_transmute_nested_constrained(anno, val, expected):
 
 @pytest.mark.parametrize(
     argnames="t, v",
-    argvalues=[(objects.Typic, {"var": "foo"}), (objects.TDict, {"a": 1})],
+    argvalues=[
+        (objects.Typic, {"var": "foo"}),
+        (objects.TDict, {"a": 1}),
+        (typing.Union[str, pathlib.Path], pathlib.Path(".")),
+        (typing.Union[str, pathlib.Path], "."),
+    ],
     ids=objects.get_id,
 )
 def test_validate(t, v):
@@ -696,6 +701,7 @@ def test_validate_transmute(t, v):
         (objects.TDict, {"a": ""}),
         (typing.Mapping[int, str], {"b": ""}),
         (typing.Mapping[pathlib.Path, str], {1: ""},),
+        (typing.Union[str, pathlib.Path], 1),
     ],
     ids=objects.get_id,
 )


### PR DESCRIPTION
This resolves #85 