### PR TITLE
Pandas Validation Errors & Regressions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,6 @@ repos:
     hooks:
     - id: flake8
   - repo: .
-    rev: v2.0.19
+    rev: v2.0.20
     hooks:
     - id: export-requirements-dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.0.20"
+version = "2.0.21"
 description = "Typical: Python's Typing Toolkit."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/typic/serde/des.py
+++ b/typic/serde/des.py
@@ -374,7 +374,9 @@ class DesFactory:
                 x = f"{kd_name}(x)"
                 y = f"{it_name}(y)"
             line = f"{anno_name}({{{x}: {y} for x, y in {iterate}}})"
-
+        # If we don't have nested annotations, we can short-circuit on valid inputs
+        else:
+            self._add_type_check(func, anno_name)
         # Write the lines.
         func.l(
             f"{self.VNAME} = {line}",
@@ -401,8 +403,8 @@ class DesFactory:
                 f"{self.VNAME} = "
                 f"{anno_name}({it_name}(x) for x in parent({iterate}))"
             )
-
-        self._add_eval(func)
+        else:
+            self._add_type_check(func, anno_name)
         func.l(
             line,
             level=None,

--- a/typic/util.py
+++ b/typic/util.py
@@ -27,6 +27,7 @@ from typing import (
     MutableSet,
     Dict,
     Optional,
+    ForwardRef,
 )
 
 import typic.checks as checks
@@ -213,6 +214,8 @@ def get_name(obj: Type) -> str:
     """
     if hasattr(obj, "_name") and not hasattr(obj, "__name__"):
         return obj._name
+    elif isinstance(obj, ForwardRef):
+        return obj.__forward_arg__
     return obj.__name__
 
 
@@ -220,7 +223,8 @@ def get_name(obj: Type) -> str:
 def get_qualname(obj: Type) -> str:
     if hasattr(obj, "_name") and not hasattr(obj, "__name__"):
         return repr(obj)
-
+    elif isinstance(obj, ForwardRef):
+        return obj.__forward_arg__
     qualname = getattr(obj, "__qualname__", obj.__name__)
     if "<locals>" in qualname:
         return obj.__name__

--- a/typic/util.py
+++ b/typic/util.py
@@ -8,7 +8,7 @@ import inspect
 import sys
 from threading import RLock
 from types import MappingProxyType
-from typing import (
+from typing import (  # type: ignore  # ironic...
     Tuple,
     Any,
     Sequence,


### PR DESCRIPTION
Bugfixes:
- Properly handle ForwardRefs when fetching a type-name.
- Properly handle equality checks for pandas types (resolves #106).
- Short-circuit collection-types with no defined nested types/fields (resolves #107).