### PR TITLE
Improve Deserialization with Defaults and Postponed Annotations

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ theme:
   favicon: "static/favicon/favicon.ico"
   logo: "static/c3p-white.png"
   palette:
-    primary: "indigo"
+    primary: "cyan"
     accent: "amber"
   font:
     text: "IBM Plex Serif"

--- a/mkdocs/usage/api.md
+++ b/mkdocs/usage/api.md
@@ -90,8 +90,11 @@ is also accepted by `@typic.klass`, plus a few more:
 > Generate a JSON Schema definition for your object.
 
 `serde: SerdeFlags = None`
-> Customize the serialization & deserialization of your object. See
-> [SerDes](serdes.md).
+> Customize the serialization & deserialization of your object. See [SerDes](serdes.md).
+
+`slots: bool = True`
+> Automatically generate a class with slots for the attributes defined by your
+> annotations.
 
 ### Interacting With Your Objects
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.0.22"
+version = "2.0.23"
 description = "Typical: Python's Typing Toolkit."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/tests/objects.py
+++ b/tests/objects.py
@@ -68,13 +68,49 @@ class DefaultEllipsis:
     ellipsis: str = ...
 
 
-@dataclasses.dataclass
+@typic.klass
 class Forward:
     foo: "FooNum"
 
 
 class FooNum(str, enum.Enum):
     bar = "bar"
+
+
+@typic.klass
+class A:
+    b: typing.Optional["B"] = None
+
+
+@typic.klass
+class B:
+    a: typing.Optional["A"] = None
+
+
+@typic.klass
+class C:
+    c: typing.Optional["C"] = None
+
+
+@dataclasses.dataclass
+class D:
+    d: typing.Optional["D"] = None
+
+
+@dataclasses.dataclass
+class E:
+    d: typing.Optional[D] = None
+    f: typing.Optional["F"] = None
+
+
+@dataclasses.dataclass
+class F:
+    g: "G"
+
+
+@typic.klass
+class G:
+    h: typing.Optional[int] = None
 
 
 class Class:

--- a/typic/api.py
+++ b/typic/api.py
@@ -210,6 +210,7 @@ def _resolve_class(
     }
     if jsonschema:
         ns["schema"] = classmethod(schema)
+        schema_builder.attach(cls)
 
     # Frozen dataclasses don't use the native setattr
     # So we wrap the init. This should be fine,
@@ -242,8 +243,6 @@ def _resolve_class(
     proto: SerdeProtocol = resolver.resolve(cls, is_strict=strict)
     # Bind it to the new class
     _bind_proto(cls, proto)
-    if jsonschema:
-        schema(cls)
     # Track resolution state.
     setattr(cls, "__typic_resolved__", True)
     return cls
@@ -538,9 +537,9 @@ def constrained(
             raise TypeError(f"can't constrain type {cls_.__name__!r}")
 
         args: Tuple[Type, ...] = ()
-        if values and constr_cls.type in {list, dict, set, tuple, frozenset}:
+        if values and constr_cls.type in {list, dict, set, tuple, frozenset}:  # type: ignore
             args = _handle_constraint_values(constraints, values, args)
-        if constr_cls.type == dict:
+        if constr_cls.type == dict:  # type: ignore
             args = _handle_constraint_keys(constraints, args)
         if args:
             cdict["__args__"] = args

--- a/typic/compat.py
+++ b/typic/compat.py
@@ -1,13 +1,41 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 # flake8: noqa
+import sys
+from typing import TYPE_CHECKING, Any
+
 try:
     from typing import Final, TypedDict  # type: ignore
 except ImportError:  # pragma: nocover
     from typing_extensions import Final, TypedDict  # type: ignore
+try:
+    from typing import ForwardRef  # type: ignore
+except ImportError:  # pragma: nocover
+    from typing import _ForwardRef as ForwardRef  # type: ignore
 try:
     from sqlalchemy import MetaData as SQLAMetaData  # type: ignore
 except ImportError:  # pragma: nocover
 
     class SQLAMetaData:  # type: ignore
         ...
+
+
+if sys.version_info < (3, 7):  # pragma: nocover
+    if TYPE_CHECKING:
+
+        class ForwardRef:
+            def _eval_type(self, globalns: Any, localns: Any) -> Any:
+                pass
+
+    else:
+        from typing import _ForwardRef as ForwardRef
+
+    def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
+        return type_._eval_type(globalns, localns)
+
+
+else:  # pragma: nocover
+    from typing import ForwardRef  # type: ignore
+
+    def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
+        return type_._evaluate(globalns, localns)

--- a/typic/constraints/array.py
+++ b/typic/constraints/array.py
@@ -152,7 +152,7 @@ class ArrayConstraints(BaseConstraints):
                 f"{o.__name__}("
                 f"({itval}(x, field={field}) for i, x in enumerate({self.VALUE}))"
                 f")",
-                **ctx,
+                **ctx,  # type: ignore
             )
         return asserts, context
 

--- a/typic/serde/des.py
+++ b/typic/serde/des.py
@@ -120,29 +120,34 @@ class DesFactory:
             self._add_eval(func)
         # Equality checks for defaults and optionals
         custom_equality = hasattr(annotation.resolved_origin, "equals")
-        check_values: Tuple[Any, ...] = ()
-        eq = None
+        if custom_equality and (annotation.optional or annotation.has_default):
+            func.l(f"custom_equality = hasattr({self.VNAME}, 'equals')")
+        null = ""
         if annotation.optional:
-            check_values = self.resolver.OPTIONALS[:]
-        if annotation.has_default:
-            check_values = (annotation.parameter.default, *check_values)
-        if check_values:
-            eq = f"{self.VNAME} in __defaults"
+            null = f"{self.VNAME} in {self.resolver.OPTIONALS}"
             if custom_equality:
-                func.l(f"custom_equality = hasattr({self.VNAME}, 'equals')")
-                eq = (
-                    f"(any({self.VNAME}.equals(d) for d in __defaults) "
+                null = (
+                    f"(any({self.VNAME}.equals(o) for o in {self.resolver.OPTIONALS}) "
                     "if custom_equality "
-                    f"else {eq})"
+                    f"else {null})"
                 )
-            _ctx["__defaults"] = check_values
-        if eq:
-            pre = ""
-            # Subclassed enums mixed with types pass eq checks for the mixed type.
-            # We don't want to short-circuit, though, if the input isn't the Enum inst.
-            if checks.isenumtype(annotation.resolved_origin):
-                pre = f"{self.VTYPE} is {anno_name} and "
-            with func.b(f"if {pre}{eq}:", **_ctx) as b:  # type: ignore
+        eq = ""
+        if (
+            annotation.has_default
+            and annotation.parameter.default not in self.resolver.OPTIONALS
+        ):
+            eq = f"{self.VNAME} == __default"
+            if custom_equality:
+                if hasattr(annotation.parameter.default, "equals"):
+                    eq = f"__default.equals({self.VNAME})"
+                eq = f"{self.VNAME}.equals(__default) if custom_equality else {eq}"
+            _ctx["__default"] = annotation.parameter.default
+        if eq or null:
+            # Add a type-check for anything that isn't a builtin.
+            if eq and not checks.isbuiltintype(annotation.resolved_origin):
+                eq = f"{self.VTYPE} is {anno_name} and {eq}"
+            check = " or ".join(c for c in (null, eq) if c)
+            with func.b(f"if {check}:", **_ctx) as b:  # type: ignore
                 b.l(f"return {self.VNAME}")
 
     @staticmethod


### PR DESCRIPTION
- Fixes premature short-circuiting of deserializers for annotations with default values (resolves #112)
- Adds support for postponed annotations and recursive/circular types (resolves #113)