### PR TITLE
Fixes for Generator Deserialization and Recursion Detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.0.23"
+version = "2.0.24"
 description = "Typical: Python's Typing Toolkit."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -131,6 +131,7 @@ def test_isbuiltintype(obj: typing.Any):
         (objects.Dest, objects.Source(), objects.Dest(objects.Source().test)),  # type: ignore
         (MyClass, factory(), MyClass(1)),
         (defaultdict, {}, defaultdict(None)),
+        (list, (x for x in range(10)), [*range(10)]),
     ],
     ids=objects.get_id,
 )

--- a/typic/checks.py
+++ b/typic/checks.py
@@ -19,6 +19,7 @@ from typing import (
     Type,
     Tuple,
     TypeVar,
+    Iterable,
 )
 
 import typic
@@ -365,6 +366,12 @@ def isuuidtype(obj: Type[ObjectT]) -> bool:
 
 
 _COLLECTIONS = {list, set, tuple, frozenset, dict, str, bytes}
+
+
+@functools.lru_cache(maxsize=None)
+def isiterabletype(obj: Type[ObjectT]):
+    obj = util.origin(obj)
+    return _issubclass(obj, Iterable)
 
 
 @functools.lru_cache(maxsize=None)

--- a/typic/constraints/common.py
+++ b/typic/constraints/common.py
@@ -460,6 +460,16 @@ class DelayedConstraints:
 
 
 class ForwardDelayedConstraints:
+    __slots__ = (
+        "ref",
+        "module",
+        "localns",
+        "nullable",
+        "name",
+        "factory",
+        "_constraints",
+    )
+
     def __init__(
         self,
         ref: ForwardRef,

--- a/typic/serde/translator.py
+++ b/typic/serde/translator.py
@@ -12,7 +12,7 @@ from typing import (
     Any,
 )
 
-from typic.checks import iscollectiontype, ismappingtype
+from typic.checks import ismappingtype, isiterabletype
 from typic.gen import Block, Keyword
 from typic.util import (
     cached_type_hints,
@@ -132,7 +132,7 @@ class TranslatorFactory:
             iter = _valuescaller if values else _itemscaller
             return iter
 
-        if iscollectiontype(type):
+        if isiterabletype(type):
             return _iter
 
         fields = self.get_fields(type, as_source=True) or {}


### PR DESCRIPTION
- Use live trace to track seen frames rather than count all the frames in the stack when checking for recursion (resolves #116)
- Check for iterable types instead of collection types when resolving an iterator for an object (resolves #115)