### PR TITLE
Fix Bottleneck when Handling Recursive Types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.0.24"
+version = "2.0.25"
 description = "Typical: Python's Typing Toolkit."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/tests/objects.py
+++ b/tests/objects.py
@@ -88,6 +88,12 @@ class B:
 
 
 @typic.klass
+class ABs:
+    a: typing.Optional[A] = None
+    bs: typing.Optional[typing.Iterable[B]] = None
+
+
+@typic.klass
 class C:
     c: typing.Optional["C"] = None
 

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -823,6 +823,11 @@ def test_prevent_recursion_with_slots():
             {"d": {}, "f": {"g": {"h": "1"}}},
             objects.E(objects.D(), objects.F(objects.G(1))),
         ),
+        (
+            objects.ABs,
+            {"a": {}, "bs": [{}]},
+            objects.ABs(a=objects.A(), bs=[objects.B()]),
+        ),
     ],
 )
 def test_recursive_transmute(annotation, value, expected):
@@ -842,6 +847,7 @@ def test_recursive_transmute(annotation, value, expected):
         (objects.D, {"d": {}}),
         (objects.E, {}),
         (objects.E, {"d": {}, "f": {"g": {"h": 1}}},),
+        (objects.ABs, {"a": {}, "bs": [{}]},),
     ],
 )
 def test_recursive_validate(annotation, value):
@@ -862,6 +868,10 @@ def test_recursive_validate(annotation, value):
         (
             objects.E(objects.D(), objects.F(objects.G(1))),
             {"d": {"d": None}, "f": {"g": {"h": 1}}},
+        ),
+        (
+            objects.ABs(a=objects.A(), bs=[objects.B()]),
+            {"a": {"b": None}, "bs": [{"a": None}]},
         ),
     ],
 )

--- a/typic/constraints/array.py
+++ b/typic/constraints/array.py
@@ -162,7 +162,6 @@ class ArrayConstraints(BaseConstraints):
             minItems=self.min_items,
             maxItems=self.max_items,
             uniqueItems=self.unique,
-            items=self.values.for_schema(with_type=True) if self.values else None,
         )
         if with_type:
             schema["type"] = "array"

--- a/typic/constraints/common.py
+++ b/typic/constraints/common.py
@@ -3,6 +3,7 @@
 import abc
 import dataclasses
 import enum
+import reprlib
 import sys
 import warnings
 from inspect import Signature
@@ -58,10 +59,8 @@ class __AbstractConstraints(abc.ABC):
 
     __slots__ = ("__dict__",)
 
-    def __post_init__(self):
-        self.validator
-
     @util.cached_property
+    @reprlib.recursive_repr()
     def __str(self) -> str:
         fields = [f"type={self.type_qualname}"]
         for f in dataclasses.fields(self):
@@ -192,6 +191,9 @@ class BaseConstraints(__AbstractConstraints):
     Even in `strict` mode, we may still want to coerce after validation.
     """
     name: Optional[str] = None
+
+    def __post_init__(self):
+        self.validator
 
     def _build_validator(
         self, func: gen.Block
@@ -365,6 +367,9 @@ class TypeConstraints(__AbstractConstraints):
     """Whether this constraint can allow null values."""
     name: Optional[str] = None
 
+    def __post_init__(self):
+        self.validator
+
     @util.cached_property
     def validator(self) -> ValidatorT:
         ns = dict(__t=self.type, VT=VT)
@@ -399,6 +404,9 @@ class EnumConstraints(__AbstractConstraints):
     """Whether this constraint can allow null values."""
     coerce: bool = True
     name: Optional[str] = None
+
+    def __post_init__(self):
+        self.validator
 
     @util.cached_property
     def __str(self) -> str:

--- a/typic/constraints/mapping.py
+++ b/typic/constraints/mapping.py
@@ -329,26 +329,6 @@ class MappingConstraints(BaseConstraints):
             propertyNames=(
                 {"pattern": self.key_pattern.pattern} if self.key_pattern else None
             ),
-            patternProperties=(
-                {x: y.for_schema() for x, y in self.patterns.items()}
-                if self.patterns
-                else None
-            ),
-            additionalProperties=(
-                self.values.for_schema(with_type=True)
-                if self.values
-                else not self.total
-            ),
-            dependencies=(
-                {
-                    x: y.for_schema(with_type=True)
-                    if isinstance(y, BaseConstraints)
-                    else y
-                    for x, y in self.key_dependencies.items()
-                }
-                if self.key_dependencies
-                else None
-            ),
         )
         if with_type:
             schema["type"] = "object"

--- a/typic/ext/schema/field.py
+++ b/typic/ext/schema/field.py
@@ -8,6 +8,7 @@ import enum
 import ipaddress
 import pathlib
 import re
+import reprlib
 import uuid
 from typing import (
     ClassVar,
@@ -136,7 +137,7 @@ class BaseSchemaField(_Serializable):
     writeOnly: Optional[bool] = None
     extensions: Optional[Tuple[frozendict.FrozenDict[str, Any], ...]] = None
 
-    __repr = cached_property(filtered_repr)
+    __repr = cached_property(reprlib.recursive_repr()(filtered_repr))
 
     def __repr__(self) -> str:  # pragma: nocover
         return self.__repr
@@ -325,6 +326,7 @@ SchemaFieldT = Union[
     MultiSchemaField,
     UndeclaredSchemaField,
     NullSchemaField,
+    Ref,
 ]
 """A type-alias for the defined JSON Schema Fields."""
 

--- a/typic/klass.py
+++ b/typic/klass.py
@@ -146,7 +146,7 @@ def make_typedclass(
     )
     if slots:
         try:
-            with guard_recursion():
+            with guard_recursion():  # pragma: nocover
                 dcls = slotted(dcls)
         except RecursionDetected:
             raise TypeError(

--- a/typic/serde/common.py
+++ b/typic/serde/common.py
@@ -1,5 +1,6 @@
 import dataclasses
 import inspect
+import reprlib
 import sys
 import warnings
 from typing import (
@@ -222,6 +223,19 @@ class ForwardDelayedAnnotation:
     _name: Optional[str] = None
     _resolved: Optional["SerdeProtocol"] = dataclasses.field(default=None)
 
+    @reprlib.recursive_repr()
+    def __repr__(self):
+        return (
+            f"{self.__class__}("
+            f"ref={self.ref},"
+            f"module={self.module}!r, "
+            f"parameter={self.parameter}, "
+            f"is_optional={self.is_optional}, "
+            f"is_strict={self.is_strict}, "
+            f"flags={self.flags}, "
+            f"default={self.default})"
+        )
+
     @property
     def resolved(self):
         if self._resolved is None:
@@ -230,7 +244,7 @@ class ForwardDelayedAnnotation:
                 type = evaluate_forwardref(self.ref, globalns or {}, self.localns or {})
             except NameError as e:
                 warnings.warn(
-                    f"Counldn't resolve forward reference: {e}. "
+                    f"Couldn't resolve forward reference: {e}. "
                     f"Make sure this type is available in {self.module}."
                 )
                 type = Any
@@ -263,6 +277,17 @@ class DelayedAnnotation:
     default: Any = _empty
     _name: Optional[str] = None
     _resolved: Optional["SerdeProtocol"] = dataclasses.field(default=None)
+
+    @reprlib.recursive_repr()
+    def __repr__(self):
+        return (
+            f"{self.__class__}("
+            f"parameter={self.parameter}, "
+            f"is_optional={self.is_optional}, "
+            f"is_strict={self.is_strict}, "
+            f"flags={self.flags}, "
+            f"default={self.default})"
+        )
 
     @property
     def resolved(self):

--- a/typic/util.py
+++ b/typic/util.py
@@ -47,7 +47,6 @@ __all__ = (
     "filtered_repr",
     "get_args",
     "get_name",
-    "hexhash",
     "origin",
     "resolve_supertype",
     "safe_eval",
@@ -80,10 +79,6 @@ GENERIC_TYPE_MAP = {
     Hashable: str,
     collections.abc.Hashable: str,
 }
-
-
-def hexhash(*args, __order=sys.byteorder, **kwargs) -> str:
-    return hash(f"{args}{kwargs}").to_bytes(8, __order, signed=True).hex()
 
 
 @functools.lru_cache(maxsize=2000, typed=True)


### PR DESCRIPTION
As part of the changes to handle recursive types, we added recursion detection. We re-worked it in the last version to minimize its impact. However, it was still significantly hampering performance at compile-time.

This resolves that bottleneck by removing the recursion check and adding awareness of "parent" types when resolving constraints and schemas.