### PR TITLE
Further Improvements to Recursion Preventions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.0.25"
+version = "2.0.26"
 description = "Typical: Python's Typing Toolkit."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/typic/serde/ser.py
+++ b/typic/serde/ser.py
@@ -641,7 +641,7 @@ class SerFactory:
 
 
 class DelayedSerializer:
-    __slots__ = "anno", "factory", "_serializer"
+    __slots__ = "anno", "factory", "_serializer", "__name__"
 
     def __init__(
         self,
@@ -651,6 +651,7 @@ class DelayedSerializer:
         self.anno = anno
         self.factory = factory
         self._serializer: Optional[SerializerT] = None
+        self.__name__ = anno.name
 
     def __call__(self, *args, **kwargs):
         if self._serializer is None:

--- a/typic/util.py
+++ b/typic/util.py
@@ -412,12 +412,17 @@ def cached_signature(obj: Callable) -> inspect.Signature:
 
 
 def _safe_get_type_hints(annotation: Union[Type, Callable]) -> Dict[str, Type[Any]]:
-    raw_annotations = getattr(annotation, "__annotations__", None) or {}
-    module_name = getattr(annotation, "__module__", None)
-    if module_name:
-        base_globals: Optional[Dict[str, Any]] = sys.modules[module_name].__dict__
+    raw_annotations: Dict[str, Any] = {}
+    base_globals: Dict[str, Any] = {}
+    if isinstance(annotation, type):
+        for base in reversed(annotation.__mro__):
+            base_globals.update(sys.modules[base.__module__].__dict__)
+            raw_annotations.update(getattr(base, "__annotations__", None) or {})
     else:
-        base_globals = None
+        raw_annotations = getattr(annotation, "__annotations__", None) or {}
+        module_name = getattr(annotation, "__module__", None)
+        if module_name:
+            base_globals = sys.modules[module_name].__dict__
     annotations = {}
     for name, value in raw_annotations.items():
         if isinstance(value, str):
@@ -426,9 +431,9 @@ def _safe_get_type_hints(annotation: Union[Type, Callable]) -> Dict[str, Type[An
             else:
                 value = ForwardRef(value)
         try:
-            value = _eval_type(value, base_globals, None)
+            value = _eval_type(value, base_globals or None, None)
         except NameError:
-            # this is ok, it can be fixed with update_forward_refs
+            # this is ok, we deal with it later.
             pass
         annotations[name] = value
     return annotations
@@ -549,6 +554,7 @@ class RecursionDetector(bdb.Bdb):  # pragma: nocover
     def user_call(self, frame, argument_list):
         code = frame.f_code
         if code in self.stack:
+            self.stack.clear()
             raise RecursionDetected(f"Caught recursion in: {frame}")
         self.stack.add(code)
 


### PR DESCRIPTION
The Resolver now maintains an internal stack of seen annotations while resolving a given annotation. This costs considerably less memory and CPU than the `guard_recursion()` function and is more deterministic.

Additionally - this PR fixes an issue where child classes with ForwardRefs failed to report annotations from their parent classes.