### PR TITLE
Further Patches for Recursion Prevention

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.0.26"
+version = "2.0.27"
 description = "Typical: Python's Typing Toolkit."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -188,6 +188,85 @@ class Container:
                 ),
             ),
         ),
+        (
+            objects.KlassVar,
+            typic.ObjectSchemaField(
+                title="KlassVar",
+                description="KlassVar()",
+                properties={
+                    "var": typic.StrSchemaField(
+                        enum=("foo",), default="foo", readOnly=True
+                    )
+                },
+                additionalProperties=False,
+                required=(),
+                definitions=typic.FrozenDict(),
+            ),
+        ),
+        (
+            objects.KlassVarSubscripted,
+            typic.ObjectSchemaField(
+                title="KlassVarSubscripted",
+                description="KlassVarSubscripted()",
+                properties={
+                    "var": typic.StrSchemaField(
+                        enum=("foo",), default="foo", readOnly=True
+                    )
+                },
+                additionalProperties=False,
+                required=(),
+                definitions=typic.FrozenDict(),
+            ),
+        ),
+        (
+            objects.A,
+            typic.ObjectSchemaField(
+                title="A",
+                description="A(b: Union[ForwardRef('B'), NoneType] = None)",
+                properties={"b": typic.Ref(ref="#/definitions/B")},
+                additionalProperties=False,
+                required=(),
+                definitions=typic.FrozenDict(
+                    {
+                        "A": typic.ObjectSchemaField(
+                            title="A",
+                            description="A(b: Union[ForwardRef('B'), NoneType] = "
+                            "None)",
+                            properties={"b": typic.Ref(ref="#/definitions/B")},
+                            additionalProperties=False,
+                            required=(),
+                        ),
+                        "B": typic.ObjectSchemaField(
+                            title="B",
+                            description="B(a: Union[ForwardRef('A'), NoneType] = None)",
+                            properties={
+                                "a": typic.MultiSchemaField(
+                                    title="A",
+                                    anyOf=(
+                                        typic.Ref(ref="#/definitions/A"),
+                                        typic.NullSchemaField(),
+                                    ),
+                                )
+                            },
+                            additionalProperties=False,
+                            required=(),
+                        ),
+                    }
+                ),
+            ),
+        ),
+        (
+            objects.ItemizedKeyedValuedDict,
+            typic.ObjectSchemaField(
+                title="ItemizedKeyedValuedDict",
+                properties={"foo": typic.IntSchemaField()},
+                additionalProperties=typic.StrSchemaField(maxLength=5),
+            ),
+        ),
+        (
+            objects.ShortStrList,
+            typic.ArraySchemaField(items=typic.StrSchemaField(maxLength=5)),
+        ),
     ],
     ids=repr,
 )

--- a/typic/serde/common.py
+++ b/typic/serde/common.py
@@ -22,12 +22,13 @@ from typing import (
 )
 
 from typic import strict as st, util, constraints as const
+from typic.checks import isclassvartype
 from typic.common import AnyOrTypeT, Case, EMPTY, ObjectT
 from typic.compat import TypedDict, ForwardRef, evaluate_forwardref
 from typic.ext import json
 from typic.types import freeze
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: nocover
     from .resolver import Resolver
 
 
@@ -195,6 +196,7 @@ class Annotation:
     """Type restriction configuration, if any."""
     generic: Type = dataclasses.field(init=False)
     has_default: bool = dataclasses.field(init=False)
+    is_class_var: bool = dataclasses.field(init=False)
     resolved_origin: Type = dataclasses.field(init=False)
     args: Tuple[Type, ...] = dataclasses.field(init=False)
 
@@ -203,6 +205,7 @@ class Annotation:
         self.args = util.get_args(self.resolved)
         self.resolved_origin = util.origin(self.resolved)
         self.generic = getattr(self.resolved, "__origin__", self.resolved_origin)
+        self.is_class_var = isclassvartype(self.un_resolved)
 
 
 _empty = object()


### PR DESCRIPTION
- Use a stack for recursion prevention in SchemaBuilder and clean up unused paths.
- Use a stack for recursion prevention in Constraints factory.
- Properly handle ClassVar types.