### PR TITLE
Fix Regression with JSON Schema Generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.0.27"
+version = "2.0.28"
 description = "Typical: Python's Typing Toolkit."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/typic/ext/schema/field.py
+++ b/typic/ext/schema/field.py
@@ -223,6 +223,7 @@ class StrSchemaField(BaseSchemaField):
     """
 
     type = SchemaType.STR
+    format: Optional[StringFormat] = None
     pattern: Optional[Pattern] = None
     minLength: Optional[int] = None
     maxLength: Optional[int] = None

--- a/typic/serde/ser.py
+++ b/typic/serde/ser.py
@@ -503,7 +503,7 @@ class SerFactory:
 
         self._finalize_mapping_serializer(func, serdict, annotation)
 
-    def _compile_enum_serializer(self, annotation: "Annotation",) -> SerializerT:
+    def _compile_enum_serializer(self, annotation: "Annotation") -> SerializerT:
         origin: Type[enum.Enum] = cast(Type[enum.Enum], annotation.resolved_origin)
         ts = {type(x.value) for x in origin}
         # If we can predict a single type the return the serializer for that


### PR DESCRIPTION
This patches a regression when generating string schemas with a specific format (resolves #21 )