### PR TITLE
Schema generation: Name objects after their type rather the field nam…

### DIFF
--- a/tests/objects.py
+++ b/tests/objects.py
@@ -77,6 +77,12 @@ class FooNum(str, enum.Enum):
     bar = "bar"
 
 
+@dataclasses.dataclass
+class NestedDoubleReference:
+    first: Data
+    second: Data = ...
+
+
 @typic.klass
 class A:
     b: typing.Optional["B"] = None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -256,6 +256,30 @@ class Container:
             ),
         ),
         (
+            objects.NestedDoubleReference,
+            typic.ObjectSchemaField(
+                title=objects.NestedDoubleReference.__name__,
+                description=objects.NestedDoubleReference.__doc__,
+                properties=typic.FrozenDict(
+                    first=typic.Ref(ref="#/definitions/Data"),
+                    second=typic.Ref(ref="#/definitions/Data"),
+                ),
+                required=("first",),
+                additionalProperties=False,
+                definitions=typic.FrozenDict(
+                    {
+                        "Data": typic.ObjectSchemaField(
+                            title="Data",
+                            description="Data(foo: str)",
+                            properties={"foo": typic.StrSchemaField()},
+                            additionalProperties=False,
+                            required=("foo",),
+                        )
+                    }
+                ),
+            ),
+        ),
+        (
             objects.ItemizedKeyedValuedDict,
             typic.ObjectSchemaField(
                 title="ItemizedKeyedValuedDict",

--- a/typic/ext/schema/schema.py
+++ b/typic/ext/schema/schema.py
@@ -230,7 +230,7 @@ class SchemaBuilder:
             schema = dataclasses.replace(base, **config)
         else:
             try:
-                schema = self.build_schema(use, name=self.defname(use, name=name))
+                schema = self.build_schema(use)
             except (ValueError, TypeError) as e:
                 warnings.warn(f"Couldn't build schema for {use}: {e}")
                 schema = UndeclaredSchemaField(


### PR DESCRIPTION
…e where they were referenced

This helps to allow definitions to be reused.
Previously, the behavior would be that there would be 2 definitions (named `First` and `Second`) rather than one.

It's also the behavior I originally expected, as I wondered why my definitions got a different name than the name of the e.g. dataclass referencced.

However this change is backwards-incompatible. Not sure if there should be an option somewhere to configure the schema builder's behavior (it could be that you could provide callable which returns the name for an object)? If so, I'm not sure where the appropriate place, API-wise, to place such an option would be. Another option would be to make `defname` not a staticmethod so you could easily subclass `SchemaBuilder` and override `defname`.

There is also the issue that the name could conflict with another object (which can also happen with the previous naming behavior) from a different module with the same name. In that case, either an error should be thrown or perhaps the module name should be included and prepended to the type's `__name__`?

What do you think?
