### PR TITLE
Schema generation: Name objects after their type rather the field nam…

### DIFF
--- a/tests/objects.py
+++ b/tests/objects.py
@@ -77,6 +77,12 @@ class FooNum(str, enum.Enum):
     bar = "bar"
 
 
+@dataclasses.dataclass
+class NestedDoubleReference:
+    first: Data
+    second: Data = ...
+
+
 @typic.klass
 class A:
     b: typing.Optional["B"] = None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -167,6 +167,36 @@ class Container:
                 )
             ),
         ),
+        (
+            objects.NestedDoubleReference,
+            typic.ObjectSchemaField(
+                title=objects.NestedDoubleReference.__name__,
+                description=objects.NestedDoubleReference.__doc__,
+                properties=typic.FrozenDict(
+                    first=typic.Ref(ref="#/definitions/Data"),
+                    second=typic.MultiSchemaField(
+                        title="OptionalData",
+                        anyOf=(
+                            typic.Ref(ref="#/definitions/Data"),
+                            typic.NullSchemaField(),
+                        ),
+                    ),
+                ),
+                required=("first",),
+                additionalProperties=False,
+                definitions=typic.FrozenDict(
+                    {
+                        "Data": typic.ObjectSchemaField(
+                            title="Data",
+                            description="Data(foo: str)",
+                            properties={"foo": typic.StrSchemaField()},
+                            additionalProperties=False,
+                            required=("foo",),
+                        )
+                    }
+                ),
+            ),
+        ),
         (MySet, typic.ArraySchemaField(uniqueItems=True)),
         (MyURL, typic.StrSchemaField(format=typic.StringFormat.URI)),
         (MyDateTime, typic.StrSchemaField(format=typic.StringFormat.DTIME)),

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -174,13 +174,7 @@ class Container:
                 description=objects.NestedDoubleReference.__doc__,
                 properties=typic.FrozenDict(
                     first=typic.Ref(ref="#/definitions/Data"),
-                    second=typic.MultiSchemaField(
-                        title="OptionalData",
-                        anyOf=(
-                            typic.Ref(ref="#/definitions/Data"),
-                            typic.NullSchemaField(),
-                        ),
-                    ),
+                    second=typic.Ref(ref="#/definitions/Data"),
                 ),
                 required=("first",),
                 additionalProperties=False,

--- a/typic/ext/schema/schema.py
+++ b/typic/ext/schema/schema.py
@@ -145,7 +145,7 @@ class SchemaBuilder:
         wo: Optional[bool],
         name: Optional[str],
     ) -> SchemaFieldT:
-        if annotation.optional:
+        if annotation.optional and annotation.parameter.default is not ...:
             null = NullSchemaField()
             if isinstance(schema, MultiSchemaField):
                 anyOf = schema.anyOf or ()

--- a/typic/ext/schema/schema.py
+++ b/typic/ext/schema/schema.py
@@ -238,7 +238,7 @@ class SchemaBuilder:
             schema = dataclasses.replace(base, **config)
         else:
             try:
-                schema = self.build_schema(use, name=self.defname(use, name=name))
+                schema = self.build_schema(use)
             except (ValueError, TypeError) as e:
                 warnings.warn(f"Couldn't build schema for {use}: {e}")
                 schema = UndeclaredSchemaField(


### PR DESCRIPTION
…e where they were referenced

This helps to allow definitions to be reused.