### PR TITLE
Ignore member descriptors Tagged Unions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,15 +39,14 @@ jobs:
       uses: actions/cache@v1
       id: cache
       with:
-        path: ~/.virtualenvs
+        path: ./.venv
         key: ${{ runner.os }}-${{ matrix.python-version }}-poetry-${{ hashFiles('poetry.lock') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.python-version }}-poetry-${{ hashFiles('poetry.lock') }}
 
     - name: Set Poetry config
       run: |
-        poetry config virtualenvs.in-project false
-        poetry config virtualenvs.path ~/.virtualenvs
+        poetry config virtualenvs.in-project true
 
     - name: Install Dependencies
       if: ${{ !(startsWith(matrix.os, 'macos') && matrix.python-version == 3.9) }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.1.1"
+version = "2.1.2"
 description = "Typical: Python's Typing Toolkit."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/typic/klass.py
+++ b/typic/klass.py
@@ -16,8 +16,8 @@ from typing import (
 
 from typic.api import wrap_cls, ObjectT
 from typic.types import freeze
+from typic.util import slotted
 from .serde.common import SerdeFlags
-from typic.util import slotted, guard_recursion, RecursionDetected
 
 _field_slots: Tuple[str, ...] = cast(Tuple[str, ...], dataclasses.Field.__slots__) + (
     "exclude",
@@ -145,15 +145,8 @@ def make_typedclass(
         frozen=frozen,
     )
     if slots:
-        try:
-            with guard_recursion():  # pragma: nocover
-                dcls = slotted(dcls)
-        except RecursionDetected:
-            raise TypeError(
-                f"{cls!r} uses a custom metaclass {cls.__class__!r} "
-                "which is not compatible with the 'slots' operator. "
-                "See Issue #104 on GitHub for more information."
-            ) from None
+        dcls = slotted(dcls)
+
     fields = [
         f if isinstance(f, Field) else Field.from_field(f)
         for f in dataclasses.fields(dcls)

--- a/typic/util.py
+++ b/typic/util.py
@@ -10,7 +10,7 @@ import inspect
 import sys
 from datetime import date, datetime, timedelta, time
 from threading import RLock
-from types import MappingProxyType
+from types import MappingProxyType, MemberDescriptorType
 from typing import (  # type: ignore  # ironic...
     Tuple,
     Any,
@@ -769,7 +769,7 @@ def get_tag_for_types(types: Tuple[Type, ...]) -> Optional[TaggedUnion]:
         while intersection and tag is None:
             f = intersection.pop()
             v = getattr(root, f, empty)
-            if v is not empty:
+            if v is not empty and not isinstance(v, MemberDescriptorType):
                 tag = f
                 continue
             rhint = root_hints[f]

--- a/typic/util.py
+++ b/typic/util.py
@@ -608,6 +608,16 @@ def slotted(
                 object.__setattr__(self, slot, value)
 
     def wrap(cls):
+        key = repr(cls)
+        if key in _stack:
+            raise TypeError(
+                f"{cls!r} uses a custom metaclass {cls.__class__!r} "
+                "which is not compatible with automatic slots. "
+                "See Issue #104 on GitHub for more information."
+            ) from None
+
+        _stack.add(key)
+
         cls_dict = {**cls.__dict__}
         # Create only missing slots
         inherited_slots = set().union(
@@ -642,9 +652,13 @@ def slotted(
         new_cls.__qualname__ = cls.__qualname__
         new_cls.__module__ = cls.__module__
 
+        _stack.clear()
         return new_cls
 
     return wrap if _cls is None else wrap(_cls)
+
+
+_stack: MutableSet[Type] = set()
 
 
 class joinedrepr(str):


### PR DESCRIPTION
Types with slots have `member_descriptor` placeholders on the type, which should not be considered valid tags for a union, as they have no actual value.

Additionally, this PR drops our reliance on `guard_recursion` in the `slotted` decorator, which will improve performance and no longer interfere with other systems which rely on `settrace()`.