### PR TITLE
Add support for custom encoders & decoders

### DIFF
--- a/docs/usage/api.md
+++ b/docs/usage/api.md
@@ -266,6 +266,61 @@ will bind to your object when it is wrapped with `@typic.al` or
 >     It's possible to customize your serialized representation. See
 >     [SerDes](serdes.md).
 
+#### `.decode(...)`
+
+> Decode on-the-wire data into your Model.
+>
+> This is useful if you plan to use a wire-format such as Avro, protocol buffers, etc.
+>
+> To use custom decoders, pass in a callable which takes the input as its first
+> argument. All other keyword-arguments are passed on to the decoder function.
+>
+> ??? example "Decode Binary Data to Member"
+>
+>     ```python
+>     
+>     def decode(o: bytes, *, encoding: str = None):
+>         # Pretend we're using something other than a basic .decode()...
+>         return o.decode(encoding=encoding)
+>     
+>     @typic.klass(serde=typic.flags(decoder=decode)
+>     class Member:
+>         name: str
+>         instrument: Instrument
+>         id: int = None
+>     
+>     input = '{"name":"Ben","instrument":"piano","id":1}'.encode("utf-8-sig")
+>     Member.decode(input, encoding="utf-8-sig")
+>     #> Member(name='Ben', instrument=<Instrument.PIAN: 'piano'>, id=1)
+>     ```
+
+#### `.encode(...)`
+
+> Encode your Model to a custom wire-format.
+>
+> This is useful if you plan to use a wire-format such as Avro, protocol buffers, etc.
+>
+> To use custom encoders, pass in a callable which takes the Model instance as its first
+> argument. All other keyword-arguments are passed on to the encoder function.
+>
+> ??? example "Encode a Member to Binary Data"
+>
+>     ```python
+>     
+>     def encode(o: bytes, *, encoding: str = None):
+>         # Pretend we're using something other than a basic .decode()...
+>         return o.encode(encoding=encoding)
+>     
+>     @typic.klass(serde=typic.flags(encoder=encode)
+>     class Member:
+>         name: str
+>         instrument: Instrument
+>         id: int = None
+>     
+>     m = Member(name="Ben", instrument="piano", id=1)
+>     m.encode()
+>     #> b'{"name":"Ben","instrument":"piano","id":1}'
+>     ```
 
 ## The Functional API
 
@@ -524,6 +579,52 @@ class Song:
 >
 >     It's possible to customize your serialized representation. See
 >     [SerDes](serdes.md).
+
+#### `typic.decode(...)`
+
+> Decode on-the-wire data into your Model.
+>
+> This is useful if you plan to use a wire-format such as Avro, protocol buffers, etc.
+>
+> To use custom decoders, pass in a callable which takes the input as its first
+> argument. All other keyword-arguments are passed on to the decoder function.
+>
+> ??? example "Decode Binary Data to Member"
+>
+>     ```python
+>     
+>     def decode(o: bytes, *, encoding: str = None):
+>         # Pretend we're using something other than a basic .decode()...
+>         return o.decode(encoding=encoding)
+>     
+>     input = '{"name":"Ben","instrument":"piano","id":1}'.encode("utf-8-sig")
+>     typic.decode(Member, input, decoder=decode, encoding="utf-8-sig")
+>     #> Member(name='Ben', instrument=<Instrument.PIAN: 'piano'>, id=1)
+>     ```
+
+#### `typic.encode(...)`
+
+> Encode your Model to a custom wire-format.
+>
+> This is useful if you plan to use a wire-format such as Avro, protocol buffers, etc.
+>
+> To use custom encoders, pass in a callable which takes the primitive representation of
+> your Model as the first argument. All other keyword-arguments are passed on to the
+> encoder function.
+>
+> ??? example "Encode a Member to Binary Data"
+>
+>     ```python
+>     import ujson
+>     
+>     def encode(o: Any, *, encoding: str = None) -> bytes:
+>         # Pretend we're using something other than a basic dumps().encode()...
+>         return ujson.dumps(o).encode(encoding=encoding)
+>     
+>     m = Member(name="Ben", instrument=Instrument.PIAN, id=1)
+>     typic.encode(m, encoder=encode)
+>     #> b'{"name":"Ben","instrument":"piano","id":1}'
+>     ```
 
 
 ## The Protocol API

--- a/tests/test_serdes.py
+++ b/tests/test_serdes.py
@@ -166,9 +166,9 @@ class CaseDict(Dict):
         ),
     ],
 )
-def test_serde_serializer(t, obj, prim):
+def test_serde_serialize(t, obj, prim):
     r = typic.resolver.resolve(t)
-    assert r.primitive(obj) == prim
+    assert r.serialize(obj) == prim
 
 
 @pytest.mark.parametrize(
@@ -196,9 +196,9 @@ def test_serde_serializer(t, obj, prim):
         ),
     ],
 )
-def test_serde_deserializer(t, obj, prim):
+def test_serde_deserialize(t, obj, prim):
     r = typic.resolver.resolve(t)
-    assert r.deserializer(prim) == obj
+    assert r.deserialize(prim) == obj
 
 
 @typic.klass

--- a/tests/test_serdes.py
+++ b/tests/test_serdes.py
@@ -23,20 +23,20 @@ class FieldMapp:
     foo_bar: str = typic.field(default="bar", name="foo")
 
 
-@typic.klass(serde=typic.SerdeFlags(case=typic.common.Case.CAMEL))
+@typic.klass(serde=typic.flags(case=typic.common.Case.CAMEL))
 class Camel:
 
     foo_bar: str = "bar"
 
 
-@typic.klass(serde=typic.SerdeFlags(signature_only=True))
+@typic.klass(serde=typic.flags(signature_only=True))
 class SigOnly:
 
     foo: ClassVar[str] = "foo"
     foo_bar: str = "bar"
 
 
-@typic.klass(serde=typic.SerdeFlags(omit=("bar",)))
+@typic.klass(serde=typic.flags(omit=("bar",)))
 class Omit:
 
     bar: str = "foo"
@@ -121,19 +121,15 @@ _VT = TypeVar("_VT")
 
 
 class GenDict(Generic[_KT, _VT], Dict):
-    __serde_flags__ = typic.SerdeFlags(
-        fields=("foo_bar",), case=typic.common.Case.CAMEL
-    )
+    __serde_flags__ = typic.flags(fields=("foo_bar",), case=typic.common.Case.CAMEL)
 
 
 class SerDict(Dict):
-    __serde_flags__ = typic.SerdeFlags(
-        fields=("foo_bar",), case=typic.common.Case.CAMEL
-    )
+    __serde_flags__ = typic.flags(fields=("foo_bar",), case=typic.common.Case.CAMEL)
 
 
 class CaseDict(Dict):
-    __serde_flags__ = typic.SerdeFlags(case=typic.common.Case.CAMEL)
+    __serde_flags__ = typic.flags(case=typic.common.Case.CAMEL)
 
 
 @pytest.mark.parametrize(
@@ -288,12 +284,12 @@ def test_invalid_serializer(type, value):
 
 
 def test_inherited_serde_flags():
-    @typic.klass(serde=typic.SerdeFlags(omit=(1,)))
+    @typic.klass(serde=typic.flags(omit=(1,)))
     class Foo:
         a: str
         b: str = typic.field(exclude=True)
 
-    @typic.klass(serde=typic.SerdeFlags(omit=(2,)))
+    @typic.klass(serde=typic.flags(omit=(2,)))
     class Bar(Foo):
         c: int
 

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -571,7 +571,7 @@ def test_register():
         return args.issubset({*MyCustomType.__args__})
 
     register(MyCustomClass, ismycustomclass)
-    assert resolver.resolve(MyCustomType).deserializer is MyCustomClass
+    assert resolver.resolve(MyCustomType).deserialize is MyCustomClass
 
 
 @pytest.mark.parametrize(argnames=("val",), argvalues=[(1,), ("foo",)])

--- a/typic/api.py
+++ b/typic/api.py
@@ -67,6 +67,8 @@ __all__ = (
     "Case",
     "coerce",
     "constrained",
+    "decode",
+    "encode",
     "environ",
     "EnvironmentTypeError",
     "EnvironmentValueError",
@@ -117,6 +119,8 @@ protocol = resolver.resolve
 tojson = resolver.tojson
 iterate = resolver.iterate
 flags = SerdeFlags
+encode = resolver.encode
+decode = resolver.decode
 
 # TBDeprecated
 coerce = resolver.coerce_value
@@ -192,6 +196,8 @@ def _bind_proto(cls, proto: SerdeProtocol):
         ("transmute", staticmethod(proto.transmute)),
         ("validate", staticmethod(proto.validate)),
         ("translate", proto.translate),
+        ("encode", proto.encode),
+        ("decode", staticmethod(proto.decode)),
     ):
         setattr(cls, n, attr)
 

--- a/typic/api.py
+++ b/typic/api.py
@@ -70,6 +70,7 @@ __all__ = (
     "environ",
     "EnvironmentTypeError",
     "EnvironmentValueError",
+    "flags",
     "is_strict_mode",
     "iterate",
     "tojson",
@@ -115,6 +116,7 @@ protocols = resolver.protocols
 protocol = resolver.resolve
 tojson = resolver.tojson
 iterate = resolver.iterate
+flags = SerdeFlags
 
 # TBDeprecated
 coerce = resolver.coerce_value

--- a/typic/ext/schema/schema.py
+++ b/typic/ext/schema/schema.py
@@ -103,7 +103,7 @@ class SchemaBuilder:
                 config[target] = {
                     nm: self.get_field(
                         resolver.resolve(
-                            it.type, namespace=parent, is_optional=it.nullable
+                            it.type, is_optional=it.nullable, namespace=parent
                         ),
                         parent=parent,
                     )

--- a/typic/serde/des.py
+++ b/typic/serde/des.py
@@ -384,7 +384,7 @@ class DesFactory:
         with func.b(f"if issubclass({self.VTYPE}, Mapping):", Mapping=abc.Mapping) as b:
             fields_deser = {
                 x: self.resolver._resolve_from_annotation(
-                    y, _namespace=namespace
+                    y, namespace=namespace
                 ).transmute
                 for x, y in annotation.serde.fields.items()
             }
@@ -607,7 +607,7 @@ class DesFactory:
                 if serde.fields and len(matched) == len(serde.fields_in):
                     desers = {
                         f: self.resolver._resolve_from_annotation(
-                            serde.fields[f], _namespace=namespace
+                            serde.fields[f], namespace=namespace
                         ).transmute
                         for f in matched
                     }


### PR DESCRIPTION
I came across a use-case where I'm communicating via Kafka using Avro schemas. This allows a developer to pin the encoder/decoder functions generated by the avro schema client to the serde protocol.