### PR TITLE
Add support for Python3.10

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,18 +52,6 @@ jobs:
       run: "poetry run black . --check"
 
     - name: Static type-check with MyPy
-      run: "poetry run mypy typic"
-
-    - name: Test with pytest + coverage
-      run: "poetry run pytest tests typic --doctest-modules --cov --cov-config=.coveragerc --cov-report=xml "
-      if: matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest'
-
-    - name: Upload coverage to Codecov
-      if: matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest'
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-        flags: unittests,${{ matrix.python-version }}
-        name: codecov-umbrella
-        fail_ci_if_error: false
+      run: |
+        poetry run mypy --install-types
+        poetry run mypy typic

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,9 +34,9 @@ jobs:
       id: cache
       with:
         path: ./.venv
-        key: poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+        key: poetry-lint-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
         restore-keys: |
-          poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          poetry-lint-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
 
     - name: Set Poetry config
       run: |
@@ -53,5 +53,4 @@ jobs:
 
     - name: Static type-check with MyPy
       run: |
-        poetry run mypy --install-types
         poetry run mypy typic

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Test & Lint
+name: Lint
 
 on: [push]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8"]
+        python-version: ["3.9"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python-${{ matrix.python-version }} (Platform ${{ matrix.os }})

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10.0-alpha - 3.10"]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python-${{ matrix.python-version }} (Platform ${{ matrix.os }})

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ["3.8"]
 
     steps:
     - uses: actions/checkout@v2
@@ -55,9 +55,11 @@ jobs:
       run: "poetry run mypy typic"
 
     - name: Test with pytest + coverage
-      run: "poetry run pytest tests typic --doctest-modules --cov --cov-config=.coveragerc --cov-report=xml"
+      run: "poetry run pytest tests typic --doctest-modules --cov --cov-config=.coveragerc --cov-report=xml "
+      if: matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest'
 
     - name: Upload coverage to Codecov
+      if: matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,14 +3,17 @@ name: Test
 on: [push]
 
 jobs:
-  build:
+  test:
 
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10.0-alpha - 3.10"]
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v2
@@ -49,13 +52,24 @@ jobs:
         poetry config virtualenvs.in-project true
 
     - name: Install Dependencies
-      if: ${{ !(startsWith(matrix.os, 'macos') && matrix.python-version == 3.9) }}
+      if: ${{ !(startsWith(matrix.os, 'macos') && matrix.python-version >= 3.9) }}
       run: poetry install --no-dev -E tests
 
     - name: Install Dependencies (MacOS + Py3.9)
-      if: ${{ startsWith(matrix.os, 'macos') && matrix.python-version == 3.9 }}
+      if: ${{ startsWith(matrix.os, 'macos') && matrix.python-version >= 3.9 }}
       run: |
         OPENBLAS="$(brew --prefix openblas)" poetry install --no-dev -E tests
 
     - name: Test with pytest
-      run: "poetry run pytest tests typic --doctest-modules"
+      run: |
+        poetry run pytest tests typic --doctest-modules --cov --cov-config=.coveragerc --cov-report=xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        env_vars: OS,PYTHON
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,4 +18,4 @@ repos:
   - repo: .
     rev: v2.3.3
     hooks:
-    - id: export-requirements-dev
+    - id: export-requirements-docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: 21.6b0
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3.8
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
-- id: export-requirements-dev
-  name: Convert pyproject.toml to requirements-dev.txt
+- id: export-requirements-docs
+  name: Convert pyproject.toml to requirements.txt
   description: Generate requirements.txt pyproject.toml for backwards compatibility with dev requirements.
   language: system
-  entry: poetry export --dev -f requirements.txt -o requirements.txt
+  entry: poetry export -E docs -f requirements.txt -o requirements.txt --without-hashes
   files: "^pyproject.toml$"
   pass_filenames: false

--- a/poetry.lock
+++ b/poetry.lock
@@ -45,7 +45,7 @@ testing = ["pytest (>=4.6)", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3
 
 [[package]]
 name = "black"
-version = "21.6b0"
+version = "21.7b0"
 description = "The uncompromising code formatter."
 category = "main"
 optional = false
@@ -57,7 +57,7 @@ click = ">=7.1.2"
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.8.1,<1"
 regex = ">=2020.1.8"
-toml = ">=0.10.1"
+tomli = ">=0.2.6,<2.0.0"
 typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\""}
 typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
@@ -218,8 +218,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-dev = ["pre-commit (2.12.1)"]
-test = ["black (21.5b1)", "flake8 (3.9.2)", "isort (5.8.0)", "mypy (0.812)", "pytest (6.2.4)", "pytest-cov (2.11.1)", "typing-extensions (3.10.0.0)"]
+dev = ["pre-commit (==2.12.1)"]
+test = ["black (==21.5b1)", "flake8 (==3.9.2)", "isort (==5.8.0)", "mypy (==0.812)", "pytest (==6.2.4)", "pytest-cov (==2.11.1)", "typing-extensions (==3.10.0.0)"]
 
 [[package]]
 name = "ghp-import"
@@ -336,16 +336,16 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "marshmallow"
-version = "3.12.2"
+version = "3.13.0"
 description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-dev = ["pytest", "pytz", "simplejson", "mypy (0.910)", "flake8 (3.9.2)", "flake8-bugbear (21.4.3)", "pre-commit (>=2.4,<3.0)", "tox"]
-docs = ["sphinx (4.0.3)", "sphinx-issues (1.2.0)", "alabaster (0.7.12)", "sphinx-version-warning (1.1.2)", "autodocsumm (0.2.6)"]
-lint = ["mypy (0.910)", "flake8 (3.9.2)", "flake8-bugbear (21.4.3)", "pre-commit (>=2.4,<3.0)"]
+dev = ["pytest", "pytz", "simplejson", "mypy (==0.910)", "flake8 (==3.9.2)", "flake8-bugbear (==21.4.3)", "pre-commit (>=2.4,<3.0)", "tox"]
+docs = ["sphinx (==4.1.1)", "sphinx-issues (==1.2.0)", "alabaster (==0.7.12)", "sphinx-version-warning (==1.1.2)", "autodocsumm (==0.2.6)"]
+lint = ["mypy (==0.910)", "flake8 (==3.9.2)", "flake8-bugbear (==21.4.3)", "pre-commit (>=2.4,<3.0)"]
 tests = ["pytest", "pytz", "simplejson"]
 
 [[package]]
@@ -366,7 +366,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "mkdocs"
-version = "1.2.1"
+version = "1.2.2"
 description = "Project documentation with Markdown."
 category = "main"
 optional = false
@@ -461,7 +461,7 @@ python-versions = "*"
 
 [[package]]
 name = "numpy"
-version = "1.21.0"
+version = "1.21.1"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
 optional = false
@@ -480,27 +480,27 @@ pyparsing = ">=2.0.2"
 
 [[package]]
 name = "pandas"
-version = "1.1.5"
+version = "1.3.0"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = false
-python-versions = ">=3.6.1"
+python-versions = ">=3.7.1"
 
 [package.dependencies]
-numpy = ">=1.15.4"
+numpy = ">=1.17.3"
 python-dateutil = ">=2.7.3"
-pytz = ">=2017.2"
+pytz = ">=2017.3"
 
 [package.extras]
-test = ["pytest (>=4.0.2)", "pytest-xdist", "hypothesis (>=3.58)"]
+test = ["hypothesis (>=3.58)", "pytest (>=6.0)", "pytest-xdist"]
 
 [[package]]
 name = "pathspec"
-version = "0.8.1"
+version = "0.9.0"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
 name = "pendulum"
@@ -709,7 +709,7 @@ testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtuale
 
 [[package]]
 name = "python-dateutil"
-version = "2.8.1"
+version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
 category = "main"
 optional = false
@@ -771,7 +771,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "sqlalchemy"
-version = "1.4.20"
+version = "1.4.22"
 description = "Database Abstraction Library"
 category = "main"
 optional = false
@@ -844,832 +844,17 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "tomli"
+version = "1.1.0"
+description = "A lil' TOML parser"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "typed-ast"
 version = "1.4.3"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-aiofiles"
-version = "0.1.7"
-description = "Typing stubs for aiofiles"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-all"
-version = "1.0.0"
-description = "A shim for the typeshed changes in mypy 0.900"
-category = "main"
-optional = false
-python-versions = ">=3.6.1"
-
-[package.dependencies]
-types-aiofiles = "*"
-types-annoy = "*"
-types-atomicwrites = "*"
-types-backports = "*"
-types-backports-abc = "*"
-types-bleach = "*"
-types-boto = "*"
-types-cachetools = "*"
-types-certifi = "*"
-types-characteristic = "*"
-types-chardet = "*"
-types-click = "*"
-types-click-spinner = "*"
-types-colorama = "*"
-types-contextvars = "*"
-types-croniter = "*"
-types-cryptography = "*"
-types-dataclasses = "*"
-types-dateparser = "*"
-types-DateTimeRange = "*"
-types-decorator = "*"
-types-Deprecated = "*"
-types-docopt = "*"
-types-docutils = "*"
-types-emoji = "*"
-types-enum34 = "*"
-types-fb303 = "*"
-types-filelock = "*"
-types-first = "*"
-types-Flask = "*"
-types-freezegun = "*"
-types-frozendict = "*"
-types-futures = "*"
-types-geoip2 = "*"
-types-ipaddress = "*"
-types-itsdangerous = "*"
-types-JACK-Client = "*"
-types-Jinja2 = "*"
-types-kazoo = "*"
-types-Markdown = "*"
-types-MarkupSafe = "*"
-types-maxminddb = "*"
-types-mock = "*"
-types-mypy-extensions = "*"
-types-nmap = "*"
-types-openssl-python = "*"
-types-orjson = "*"
-types-paramiko = "*"
-types-pathlib2 = "*"
-types-Pillow = "*"
-types-pkg-resources = "*"
-types-polib = "*"
-types-protobuf = "*"
-types-pyaudio = "*"
-types-pycurl = "*"
-types-pyfarmhash = "*"
-types-PyJWT = "*"
-types-pymssql = "*"
-types-PyMySQL = "*"
-types-pyRFC3339 = "*"
-types-pysftp = "*"
-types-python-dateutil = "*"
-types-python-gflags = "*"
-types-python-slugify = "*"
-types-pytz = "*"
-types-pyvmomi = "*"
-types-PyYAML = "*"
-types-redis = "*"
-types-requests = "*"
-types-retry = "*"
-types-Routes = "*"
-types-scribe = "*"
-types-simplejson = "*"
-types-singledispatch = "*"
-types-six = "*"
-types-tabulate = "*"
-types-termcolor = "*"
-types-toml = "*"
-types-tornado = "*"
-types-typed-ast = "*"
-types-tzlocal = "*"
-types-ujson = "*"
-types-waitress = "*"
-types-Werkzeug = "*"
-types-xxhash = "*"
-
-[[package]]
-name = "types-annoy"
-version = "1.17.2"
-description = "Typing stubs for annoy"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-atomicwrites"
-version = "0.1.5"
-description = "Typing stubs for atomicwrites"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-backports"
-version = "0.1.3"
-description = "Typing stubs for backports"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-backports-abc"
-version = "0.1.4"
-description = "Typing stubs for backports_abc"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-bleach"
-version = "3.3.3"
-description = "Typing stubs for bleach"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-boto"
-version = "0.1.2"
-description = "Typing stubs for boto"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-six = "*"
-
-[[package]]
-name = "types-cachetools"
-version = "0.1.9"
-description = "Typing stubs for cachetools"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-certifi"
-version = "0.1.4"
-description = "Typing stubs for certifi"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-characteristic"
-version = "0.1.3"
-description = "Typing stubs for characteristic"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-chardet"
-version = "0.1.3"
-description = "Typing stubs for chardet"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-click"
-version = "7.1.2"
-description = "Typing stubs for click"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-click-spinner"
-version = "0.1.4"
-description = "Typing stubs for click-spinner"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-colorama"
-version = "0.4.2"
-description = "Typing stubs for colorama"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-contextvars"
-version = "0.1.4"
-description = "Typing stubs for contextvars"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-croniter"
-version = "0.1.4"
-description = "Typing stubs for croniter"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-cryptography"
-version = "3.3.3"
-description = "Typing stubs for cryptography"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-enum34 = "*"
-types-ipaddress = "*"
-
-[[package]]
-name = "types-dataclasses"
-version = "0.1.5"
-description = "Typing stubs for dataclasses"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-dateparser"
-version = "0.1.3"
-description = "Typing stubs for dateparser"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-datetimerange"
-version = "0.1.2"
-description = "Typing stubs for DateTimeRange"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-python-dateutil = "*"
-
-[[package]]
-name = "types-decorator"
-version = "0.1.5"
-description = "Typing stubs for decorator"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-deprecated"
-version = "0.1.3"
-description = "Typing stubs for Deprecated"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-docopt"
-version = "0.6.2"
-description = "Typing stubs for docopt"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-docutils"
-version = "0.1.7"
-description = "Typing stubs for docutils"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-emoji"
-version = "1.2.2"
-description = "Typing stubs for emoji"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-enum34"
-version = "0.1.8"
-description = "Typing stubs for enum34"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-fb303"
-version = "0.1.6"
-description = "Typing stubs for fb303"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-filelock"
-version = "0.1.4"
-description = "Typing stubs for filelock"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-first"
-version = "0.1.5"
-description = "Typing stubs for first"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-flask"
-version = "1.1.1"
-description = "Typing stubs for Flask"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-click = "*"
-types-Jinja2 = "*"
-types-Werkzeug = "*"
-
-[[package]]
-name = "types-freezegun"
-version = "0.1.4"
-description = "Typing stubs for freezegun"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-frozendict"
-version = "0.1.5"
-description = "Typing stubs for frozendict"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-futures"
-version = "0.1.6"
-description = "Typing stubs for futures"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-geoip2"
-version = "0.1.2"
-description = "Typing stubs for geoip2"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-maxminddb = "*"
-
-[[package]]
-name = "types-ipaddress"
-version = "0.1.5"
-description = "Typing stubs for ipaddress"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-itsdangerous"
-version = "1.1.2"
-description = "Typing stubs for itsdangerous"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-jack-client"
-version = "0.1.5"
-description = "Typing stubs for JACK-Client"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-jinja2"
-version = "2.11.2"
-description = "Typing stubs for Jinja2"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-MarkupSafe = "*"
-
-[[package]]
-name = "types-kazoo"
-version = "0.1.3"
-description = "Typing stubs for kazoo"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-markdown"
-version = "3.3.0"
-description = "Typing stubs for Markdown"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-markupsafe"
-version = "1.1.4"
-description = "Typing stubs for MarkupSafe"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-maxminddb"
-version = "0.1.2"
-description = "Typing stubs for maxminddb"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-ipaddress = "*"
-
-[[package]]
-name = "types-mock"
-version = "0.1.3"
-description = "Typing stubs for mock"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-mypy-extensions"
-version = "0.4.5"
-description = "Typing stubs for mypy-extensions"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-nmap"
-version = "0.1.4"
-description = "Typing stubs for nmap"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-openssl-python"
-version = "0.1.3"
-description = "Typing stubs for openssl-python"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-cryptography = "*"
-
-[[package]]
-name = "types-orjson"
-version = "0.1.1"
-description = "Typing stubs for orjson"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-paramiko"
-version = "0.1.7"
-description = "Typing stubs for paramiko"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-cryptography = "*"
-
-[[package]]
-name = "types-pathlib2"
-version = "2.2.0"
-description = "Typing stubs for pathlib2"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-pillow"
-version = "8.3.1"
-description = "Typing stubs for Pillow"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-pkg-resources"
-version = "0.1.3"
-description = "Typing stubs for pkg_resources"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-polib"
-version = "1.1.1"
-description = "Typing stubs for polib"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-protobuf"
-version = "3.17.0"
-description = "Typing stubs for protobuf"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-futures = "*"
-
-[[package]]
-name = "types-pyaudio"
-version = "0.2.2"
-description = "Typing stubs for pyaudio"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-pycurl"
-version = "0.1.3"
-description = "Typing stubs for pycurl"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-pyfarmhash"
-version = "0.2.1"
-description = "Typing stubs for pyfarmhash"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-pyjwt"
-version = "1.7.1"
-description = "Typing stubs for PyJWT"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-cryptography = "*"
-
-[[package]]
-name = "types-pymssql"
-version = "0.1.4"
-description = "Typing stubs for pymssql"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-pymysql"
-version = "1.0.0"
-description = "Typing stubs for PyMySQL"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-pyrfc3339"
-version = "0.1.1"
-description = "Typing stubs for pyRFC3339"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-pysftp"
-version = "0.2.2"
-description = "Typing stubs for pysftp"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-paramiko = "*"
-
-[[package]]
-name = "types-python-dateutil"
-version = "0.1.4"
-description = "Typing stubs for python-dateutil"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-python-gflags"
-version = "0.1.2"
-description = "Typing stubs for python-gflags"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-python-slugify"
-version = "0.1.1"
-description = "Typing stubs for python-slugify"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-pytz"
-version = "2021.1.0"
-description = "Typing stubs for pytz"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-pyvmomi"
-version = "0.1.2"
-description = "Typing stubs for pyvmomi"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-enum34 = "*"
-
-[[package]]
-name = "types-pyyaml"
-version = "5.4.3"
-description = "Typing stubs for PyYAML"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-redis"
-version = "3.5.4"
-description = "Typing stubs for redis"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-requests"
-version = "2.25.0"
-description = "Typing stubs for requests"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-retry"
-version = "0.1.3"
-description = "Typing stubs for retry"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-routes"
-version = "0.1.7"
-description = "Typing stubs for Routes"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-scribe"
-version = "0.1.3"
-description = "Typing stubs for scribe"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-fb303 = "*"
-
-[[package]]
-name = "types-simplejson"
-version = "0.1.4"
-description = "Typing stubs for simplejson"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-singledispatch"
-version = "0.1.1"
-description = "Typing stubs for singledispatch"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-six"
-version = "0.1.7"
-description = "Typing stubs for six"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-tabulate"
-version = "0.1.1"
-description = "Typing stubs for tabulate"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-termcolor"
-version = "0.1.1"
-description = "Typing stubs for termcolor"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-toml"
-version = "0.1.3"
-description = "Typing stubs for toml"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-tornado"
-version = "5.1.0"
-description = "Typing stubs for tornado"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-typed-ast"
-version = "1.4.2"
-description = "Typing stubs for typed-ast"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-tzlocal"
-version = "0.1.1"
-description = "Typing stubs for tzlocal"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-pytz = "*"
-
-[[package]]
-name = "types-ujson"
-version = "0.1.1"
-description = "Typing stubs for ujson"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-waitress"
-version = "0.1.7"
-description = "Typing stubs for waitress"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-werkzeug"
-version = "1.0.2"
-description = "Typing stubs for Werkzeug"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-xxhash"
-version = "0.1.4"
-description = "Typing stubs for xxhash"
 category = "main"
 optional = false
 python-versions = "*"
@@ -1692,7 +877,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "virtualenv"
-version = "20.5.0"
+version = "20.6.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -1748,14 +933,14 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 benchmarks = ["pytest-benchmark", "marshmallow", "toastedmarshmallow", "djangorestframework", "pydantic", "django", "pydantic", "sqlalchemy"]
 docs = ["mkdocs", "mkdocs-material", "mkdocs-awesome-pages-plugin", "pymdown-extensions"]
 json = ["ujson"]
-lint = ["mypy", "flake8", "black", "types-all"]
+lint = ["mypy", "flake8", "black"]
 schema = ["fastjsonschema"]
 tests = ["fastjsonschema", "ujson", "pydantic", "sqlalchemy", "pandas", "mypy", "pytest", "pytest-cov"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.7"
-content-hash = "44c5a31b375f72c0fbce894c5a434ac7c59c9e0e8982c8978f07a80c1e5c5dae"
+python-versions = "^3.7.1"
+content-hash = "eb99b31d37e77fd8cc15ab57ac439e92607bed8368ed5b4aa3c53bc59178b217"
 
 [metadata.files]
 appdirs = [
@@ -1775,8 +960,8 @@ attrs = [
     {file = "backports.entry_points_selectable-1.1.0.tar.gz", hash = "sha256:988468260ec1c196dab6ae1149260e2f5472c9110334e5d51adcb77867361f6a"},
 ]
 black = [
-    {file = "black-21.6b0-py3-none-any.whl", hash = "sha256:dfb8c5a069012b2ab1e972e7b908f5fb42b6bbabcba0a788b86dc05067c7d9c7"},
-    {file = "black-21.6b0.tar.gz", hash = "sha256:dc132348a88d103016726fe360cb9ede02cecf99b76e3660ce6c596be132ce04"},
+    {file = "black-21.7b0-py3-none-any.whl", hash = "sha256:1c7aa6ada8ee864db745b22790a32f94b2795c253a75d6d9b5e439ff10d23116"},
+    {file = "black-21.7b0.tar.gz", hash = "sha256:c8373c6491de9362e39271630b65b964607bc5c79c83783547d76c839b3aa219"},
 ]
 bracex = [
     {file = "bracex-2.1.1-py3-none-any.whl", hash = "sha256:64e2a6d14de9c8e022cf40539ac8468ba7c4b99550a2b05fc87fd20e392e568f"},
@@ -2003,8 +1188,8 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
 ]
 marshmallow = [
-    {file = "marshmallow-3.12.2-py2.py3-none-any.whl", hash = "sha256:d4090ca9a36cd129126ad8b10c3982c47d4644a6e3ccb20534b512badce95f35"},
-    {file = "marshmallow-3.12.2.tar.gz", hash = "sha256:77368dfedad93c3a041cbbdbce0b33fac1d8608c9e2e2288408a43ce3493d2ff"},
+    {file = "marshmallow-3.13.0-py2.py3-none-any.whl", hash = "sha256:dd4724335d3c2b870b641ffe4a2f8728a1380cd2e7e2312756715ffeaa82b842"},
+    {file = "marshmallow-3.13.0.tar.gz", hash = "sha256:c67929438fd73a2be92128caa0325b1b5ed8b626d91a094d2f7f2771bf1f1c0e"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
@@ -2015,8 +1200,8 @@ mergedeep = [
     {file = "mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8"},
 ]
 mkdocs = [
-    {file = "mkdocs-1.2.1-py3-none-any.whl", hash = "sha256:11141126e5896dd9d279b3e4814eb488e409a0990fb638856255020406a8e2e7"},
-    {file = "mkdocs-1.2.1.tar.gz", hash = "sha256:6e0ea175366e3a50d334597b0bc042b8cebd512398cdd3f6f34842d0ef524905"},
+    {file = "mkdocs-1.2.2-py3-none-any.whl", hash = "sha256:d019ff8e17ec746afeb54eb9eb4112b5e959597aebc971da46a5c9486137f0ff"},
+    {file = "mkdocs-1.2.2.tar.gz", hash = "sha256:a334f5bd98ec960638511366eb8c5abc9c99b9083a0ed2401d8791b112d6b078"},
 ]
 mkdocs-awesome-pages-plugin = [
     {file = "mkdocs-awesome-pages-plugin-2.5.0.tar.gz", hash = "sha256:df51e908d64a7f736b4d772e19ce8ddb30c7337e06ac3dd7a29c51c431c5606e"},
@@ -2064,68 +1249,63 @@ nodeenv = [
     {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
 ]
 numpy = [
-    {file = "numpy-1.21.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d5caa946a9f55511e76446e170bdad1d12d6b54e17a2afe7b189112ed4412bb8"},
-    {file = "numpy-1.21.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ac4fd578322842dbda8d968e3962e9f22e862b6ec6e3378e7415625915e2da4d"},
-    {file = "numpy-1.21.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:598fe100b2948465cf3ed64b1a326424b5e4be2670552066e17dfaa67246011d"},
-    {file = "numpy-1.21.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7c55407f739f0bfcec67d0df49103f9333edc870061358ac8a8c9e37ea02fcd2"},
-    {file = "numpy-1.21.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:75579acbadbf74e3afd1153da6177f846212ea2a0cc77de53523ae02c9256513"},
-    {file = "numpy-1.21.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:cc367c86eb87e5b7c9592935620f22d13b090c609f1b27e49600cd033b529f54"},
-    {file = "numpy-1.21.0-cp37-cp37m-win32.whl", hash = "sha256:d89b0dc7f005090e32bb4f9bf796e1dcca6b52243caf1803fdd2b748d8561f63"},
-    {file = "numpy-1.21.0-cp37-cp37m-win_amd64.whl", hash = "sha256:eda2829af498946c59d8585a9fd74da3f810866e05f8df03a86f70079c7531dd"},
-    {file = "numpy-1.21.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:1a784e8ff7ea2a32e393cc53eb0003eca1597c7ca628227e34ce34eb11645a0e"},
-    {file = "numpy-1.21.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bba474a87496d96e61461f7306fba2ebba127bed7836212c360f144d1e72ac54"},
-    {file = "numpy-1.21.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:fd0a359c1c17f00cb37de2969984a74320970e0ceef4808c32e00773b06649d9"},
-    {file = "numpy-1.21.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e4d5a86a5257843a18fb1220c5f1c199532bc5d24e849ed4b0289fb59fbd4d8f"},
-    {file = "numpy-1.21.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:620732f42259eb2c4642761bd324462a01cdd13dd111740ce3d344992dd8492f"},
-    {file = "numpy-1.21.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9205711e5440954f861ceeea8f1b415d7dd15214add2e878b4d1cf2bcb1a914"},
-    {file = "numpy-1.21.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ad09f55cc95ed8d80d8ab2052f78cc21cb231764de73e229140d81ff49d8145e"},
-    {file = "numpy-1.21.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a1f2fb2da242568af0271455b89aee0f71e4e032086ee2b4c5098945d0e11cf6"},
-    {file = "numpy-1.21.0-cp38-cp38-win32.whl", hash = "sha256:e58ddb53a7b4959932f5582ac455ff90dcb05fac3f8dcc8079498d43afbbde6c"},
-    {file = "numpy-1.21.0-cp38-cp38-win_amd64.whl", hash = "sha256:d2910d0a075caed95de1a605df00ee03b599de5419d0b95d55342e9a33ad1fb3"},
-    {file = "numpy-1.21.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a290989cd671cd0605e9c91a70e6df660f73ae87484218e8285c6522d29f6e38"},
-    {file = "numpy-1.21.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3537b967b350ad17633b35c2f4b1a1bbd258c018910b518c30b48c8e41272717"},
-    {file = "numpy-1.21.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ccc6c650f8700ce1e3a77668bb7c43e45c20ac06ae00d22bdf6760b38958c883"},
-    {file = "numpy-1.21.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:709884863def34d72b183d074d8ba5cfe042bc3ff8898f1ffad0209161caaa99"},
-    {file = "numpy-1.21.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bebab3eaf0641bba26039fb0b2c5bf9b99407924b53b1ea86e03c32c64ef5aef"},
-    {file = "numpy-1.21.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf680682ad0a3bef56dae200dbcbac2d57294a73e5b0f9864955e7dd7c2c2491"},
-    {file = "numpy-1.21.0-cp39-cp39-win32.whl", hash = "sha256:d95d16204cd51ff1a1c8d5f9958ce90ae190be81d348b514f9be39f878b8044a"},
-    {file = "numpy-1.21.0-cp39-cp39-win_amd64.whl", hash = "sha256:2ba579dde0563f47021dcd652253103d6fd66165b18011dce1a0609215b2791e"},
-    {file = "numpy-1.21.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3c40e6b860220ed862e8097b8f81c9af6d7405b723f4a7af24a267b46f90e461"},
-    {file = "numpy-1.21.0.zip", hash = "sha256:e80fe25cba41c124d04c662f33f6364909b985f2eb5998aaa5ae4b9587242cce"},
+    {file = "numpy-1.21.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:38e8648f9449a549a7dfe8d8755a5979b45b3538520d1e735637ef28e8c2dc50"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:fd7d7409fa643a91d0a05c7554dd68aa9c9bb16e186f6ccfe40d6e003156e33a"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a75b4498b1e93d8b700282dc8e655b8bd559c0904b3910b144646dbbbc03e062"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1412aa0aec3e00bc23fbb8664d76552b4efde98fb71f60737c83efbac24112f1"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e46ceaff65609b5399163de5893d8f2a82d3c77d5e56d976c8b5fb01faa6b671"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c6a2324085dd52f96498419ba95b5777e40b6bcbc20088fddb9e8cbb58885e8e"},
+    {file = "numpy-1.21.1-cp37-cp37m-win32.whl", hash = "sha256:73101b2a1fef16602696d133db402a7e7586654682244344b8329cdcbbb82172"},
+    {file = "numpy-1.21.1-cp37-cp37m-win_amd64.whl", hash = "sha256:7a708a79c9a9d26904d1cca8d383bf869edf6f8e7650d85dbc77b041e8c5a0f8"},
+    {file = "numpy-1.21.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:95b995d0c413f5d0428b3f880e8fe1660ff9396dcd1f9eedbc311f37b5652e16"},
+    {file = "numpy-1.21.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:635e6bd31c9fb3d475c8f44a089569070d10a9ef18ed13738b03049280281267"},
+    {file = "numpy-1.21.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4a3d5fb89bfe21be2ef47c0614b9c9c707b7362386c9a3ff1feae63e0267ccb6"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8a326af80e86d0e9ce92bcc1e65c8ff88297de4fa14ee936cb2293d414c9ec63"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:791492091744b0fe390a6ce85cc1bf5149968ac7d5f0477288f78c89b385d9af"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0318c465786c1f63ac05d7c4dbcecd4d2d7e13f0959b01b534ea1e92202235c5"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9a513bd9c1551894ee3d31369f9b07460ef223694098cf27d399513415855b68"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:91c6f5fc58df1e0a3cc0c3a717bb3308ff850abdaa6d2d802573ee2b11f674a8"},
+    {file = "numpy-1.21.1-cp38-cp38-win32.whl", hash = "sha256:978010b68e17150db8765355d1ccdd450f9fc916824e8c4e35ee620590e234cd"},
+    {file = "numpy-1.21.1-cp38-cp38-win_amd64.whl", hash = "sha256:9749a40a5b22333467f02fe11edc98f022133ee1bfa8ab99bda5e5437b831214"},
+    {file = "numpy-1.21.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d7a4aeac3b94af92a9373d6e77b37691b86411f9745190d2c351f410ab3a791f"},
+    {file = "numpy-1.21.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d9e7912a56108aba9b31df688a4c4f5cb0d9d3787386b87d504762b6754fbb1b"},
+    {file = "numpy-1.21.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:25b40b98ebdd272bc3020935427a4530b7d60dfbe1ab9381a39147834e985eac"},
+    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8a92c5aea763d14ba9d6475803fc7904bda7decc2a0a68153f587ad82941fec1"},
+    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05a0f648eb28bae4bcb204e6fd14603de2908de982e761a2fc78efe0f19e96e1"},
+    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f01f28075a92eede918b965e86e8f0ba7b7797a95aa8d35e1cc8821f5fc3ad6a"},
+    {file = "numpy-1.21.1-cp39-cp39-win32.whl", hash = "sha256:88c0b89ad1cc24a5efbb99ff9ab5db0f9a86e9cc50240177a571fbe9c2860ac2"},
+    {file = "numpy-1.21.1-cp39-cp39-win_amd64.whl", hash = "sha256:01721eefe70544d548425a07c80be8377096a54118070b8a62476866d5208e33"},
+    {file = "numpy-1.21.1-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2d4d1de6e6fb3d28781c73fbde702ac97f03d79e4ffd6598b880b2d95d62ead4"},
+    {file = "numpy-1.21.1.zip", hash = "sha256:dff4af63638afcc57a3dfb9e4b26d434a7a602d225b42d746ea7fe2edf1342fd"},
 ]
 packaging = [
     {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
     {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
 ]
 pandas = [
-    {file = "pandas-1.1.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:bf23a3b54d128b50f4f9d4675b3c1857a688cc6731a32f931837d72effb2698d"},
-    {file = "pandas-1.1.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5a780260afc88268a9d3ac3511d8f494fdcf637eece62fb9eb656a63d53eb7ca"},
-    {file = "pandas-1.1.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:b61080750d19a0122469ab59b087380721d6b72a4e7d962e4d7e63e0c4504814"},
-    {file = "pandas-1.1.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:0de3ddb414d30798cbf56e642d82cac30a80223ad6fe484d66c0ce01a84d6f2f"},
-    {file = "pandas-1.1.5-cp36-cp36m-win32.whl", hash = "sha256:70865f96bb38fec46f7ebd66d4b5cfd0aa6b842073f298d621385ae3898d28b5"},
-    {file = "pandas-1.1.5-cp36-cp36m-win_amd64.whl", hash = "sha256:19a2148a1d02791352e9fa637899a78e371a3516ac6da5c4edc718f60cbae648"},
-    {file = "pandas-1.1.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:26fa92d3ac743a149a31b21d6f4337b0594b6302ea5575b37af9ca9611e8981a"},
-    {file = "pandas-1.1.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c16d59c15d946111d2716856dd5479221c9e4f2f5c7bc2d617f39d870031e086"},
-    {file = "pandas-1.1.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3be7a7a0ca71a2640e81d9276f526bca63505850add10206d0da2e8a0a325dae"},
-    {file = "pandas-1.1.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:573fba5b05bf2c69271a32e52399c8de599e4a15ab7cec47d3b9c904125ab788"},
-    {file = "pandas-1.1.5-cp37-cp37m-win32.whl", hash = "sha256:21b5a2b033380adbdd36b3116faaf9a4663e375325831dac1b519a44f9e439bb"},
-    {file = "pandas-1.1.5-cp37-cp37m-win_amd64.whl", hash = "sha256:24c7f8d4aee71bfa6401faeba367dd654f696a77151a8a28bc2013f7ced4af98"},
-    {file = "pandas-1.1.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2860a97cbb25444ffc0088b457da0a79dc79f9c601238a3e0644312fcc14bf11"},
-    {file = "pandas-1.1.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5008374ebb990dad9ed48b0f5d0038124c73748f5384cc8c46904dace27082d9"},
-    {file = "pandas-1.1.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2c2f7c670ea4e60318e4b7e474d56447cf0c7d83b3c2a5405a0dbb2600b9c48e"},
-    {file = "pandas-1.1.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:0a643bae4283a37732ddfcecab3f62dd082996021b980f580903f4e8e01b3c5b"},
-    {file = "pandas-1.1.5-cp38-cp38-win32.whl", hash = "sha256:5447ea7af4005b0daf695a316a423b96374c9c73ffbd4533209c5ddc369e644b"},
-    {file = "pandas-1.1.5-cp38-cp38-win_amd64.whl", hash = "sha256:4c62e94d5d49db116bef1bd5c2486723a292d79409fc9abd51adf9e05329101d"},
-    {file = "pandas-1.1.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:731568be71fba1e13cae212c362f3d2ca8932e83cb1b85e3f1b4dd77d019254a"},
-    {file = "pandas-1.1.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c61c043aafb69329d0f961b19faa30b1dab709dd34c9388143fc55680059e55a"},
-    {file = "pandas-1.1.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2b1c6cd28a0dfda75c7b5957363333f01d370936e4c6276b7b8e696dd500582a"},
-    {file = "pandas-1.1.5-cp39-cp39-win32.whl", hash = "sha256:c94ff2780a1fd89f190390130d6d36173ca59fcfb3fe0ff596f9a56518191ccb"},
-    {file = "pandas-1.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:edda9bacc3843dfbeebaf7a701763e68e741b08fccb889c003b0a52f0ee95782"},
-    {file = "pandas-1.1.5.tar.gz", hash = "sha256:f10fc41ee3c75a474d3bdf68d396f10782d013d7f67db99c0efbfd0acb99701b"},
+    {file = "pandas-1.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c81b8d91e9ae861eb4406b4e0f8d4dabbc105b9c479b3d1e921fba1d35b5b62a"},
+    {file = "pandas-1.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08eeff3da6a188e24db7f292b39a8ca9e073bf841fbbeadb946b3ad5c19d843e"},
+    {file = "pandas-1.3.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:88864c1e28353b958b1f30e4193818519624ad9a1776921622a6a2a016d5d807"},
+    {file = "pandas-1.3.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:872aa91e0f9ca913046ab639d4181a899f5e592030d954d28c2529b88756a736"},
+    {file = "pandas-1.3.0-cp37-cp37m-win32.whl", hash = "sha256:92835113a67cbd34747c198d41f09f4b63f6fe11ca5643baebc7ab1e30e89e95"},
+    {file = "pandas-1.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:7d3cd2c99faa94d717ca00ea489264a291ad7209453dffbf059bfb7971fd3a61"},
+    {file = "pandas-1.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:823737830364d0e2af8c3912a28ba971296181a07950873492ed94e12d28c405"},
+    {file = "pandas-1.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c746876cdd8380be0c3e70966d4566855901ac9aaa5e4b9ccaa5ca5311457d11"},
+    {file = "pandas-1.3.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe7a549d10ca534797095586883a5c17d140d606747591258869c56e14d1b457"},
+    {file = "pandas-1.3.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:f058c786e7b0a9e7fa5e0b9f4422e0ccdd3bf3aa3053c18d77ed2a459bd9a45a"},
+    {file = "pandas-1.3.0-cp38-cp38-win32.whl", hash = "sha256:98efc2d4983d5bb47662fe2d97b2c81b91566cb08b266490918b9c7d74a5ef64"},
+    {file = "pandas-1.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:e6b75091fa54a53db3927b4d1bc997c23c5ba6f87acdfe1ee5a92c38c6b2ed6a"},
+    {file = "pandas-1.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1ff13eed501e07e7fb26a4ea18a846b6e5d7de549b497025601fd9ccb7c1d123"},
+    {file = "pandas-1.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:798675317d0e4863a92a9a6bc5bd2490b5f6fef8c17b95f29e2e33f28bef9eca"},
+    {file = "pandas-1.3.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ed4fc66f23fe17c93a5d439230ca2d6b5f8eac7154198d327dbe8a16d98f3f10"},
+    {file = "pandas-1.3.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:522bfea92f3ef6207cadc7428bda1e7605dae0383b8065030e7b5d0266717b48"},
+    {file = "pandas-1.3.0-cp39-cp39-win32.whl", hash = "sha256:7897326cae660eee69d501cbfa950281a193fcf407393965e1bc07448e1cc35a"},
+    {file = "pandas-1.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:b10d7910ae9d7920a5ff7816d794d99acbc361f7b16a0f017d4fa83ced8cb55e"},
+    {file = "pandas-1.3.0.tar.gz", hash = "sha256:c554e6c9cf2d5ea1aba5979cc837b3649539ced0e18ece186f055450c86622e2"},
 ]
 pathspec = [
-    {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
-    {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
+    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
+    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
 ]
 pendulum = [
     {file = "pendulum-2.1.2-cp27-cp27m-macosx_10_15_x86_64.whl", hash = "sha256:b6c352f4bd32dff1ea7066bd31ad0f71f8d8100b9ff709fb343f3b86cee43efe"},
@@ -2234,8 +1414,8 @@ pytest-cov = [
     {file = "pytest_cov-2.12.1-py2.py3-none-any.whl", hash = "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a"},
 ]
 python-dateutil = [
-    {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
-    {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
@@ -2328,36 +1508,36 @@ six = [
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 sqlalchemy = [
-    {file = "SQLAlchemy-1.4.20-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:525dd3c2205b11a2bc6d770bf1ec63bde0253fd754b4c19c399d27ddc9dad0d3"},
-    {file = "SQLAlchemy-1.4.20-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:4a67371752fd86d1d03a3b82d4e75404608f6f4d579b9676124079a22a40c79f"},
-    {file = "SQLAlchemy-1.4.20-cp27-cp27m-win32.whl", hash = "sha256:7150e5b543b466f45f668b352f7abda27998cc8035f051d1b7e9524ca9eb2f5f"},
-    {file = "SQLAlchemy-1.4.20-cp27-cp27m-win_amd64.whl", hash = "sha256:6da83225a23eaf7b3f48f3d5f53c91b2cf00fbfa48b24a7a758160112dd3e123"},
-    {file = "SQLAlchemy-1.4.20-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:9841762d114018c49483c089fa2d47f7e612e57666323f615913d7d7f46e9606"},
-    {file = "SQLAlchemy-1.4.20-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:eaee5dd378f6f0d7c3ec49aeeb26564d55ac0ad73b9b4688bf29e66deabddf73"},
-    {file = "SQLAlchemy-1.4.20-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9eb25bcf9161e2fcbe9eebe8e829719b2334e849183f0e496bf4b83722bcccfa"},
-    {file = "SQLAlchemy-1.4.20-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8d860c62e3f51623ccd528d8fac44580501df557d4b467cc5581587fcf057719"},
-    {file = "SQLAlchemy-1.4.20-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f6d467b67a7e5048f1408e8ea60d6caa70be5b386d0eebbf1185ab49cb8c7e4"},
-    {file = "SQLAlchemy-1.4.20-cp36-cp36m-win32.whl", hash = "sha256:ff8bebc7a9d297dff2003460e01db2c20c63818b45fb19170f388b1a72fe5a14"},
-    {file = "SQLAlchemy-1.4.20-cp36-cp36m-win_amd64.whl", hash = "sha256:46361690f1e1c5385994a4caeb6e8126063ff593a5c635700bbc1245de793c1e"},
-    {file = "SQLAlchemy-1.4.20-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:c0eb2cd3ad4967fcbdd9e066e8cd91fe2c23c671dbae9952f0b4d3d42832cc5f"},
-    {file = "SQLAlchemy-1.4.20-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76fbc24311a3d039d6cd147d396719f606d96d1413f3816c028a48e29367f646"},
-    {file = "SQLAlchemy-1.4.20-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f14acb0fd16d404fda9370f93aace682f284340c89c3442ac747c5466ac7e2b5"},
-    {file = "SQLAlchemy-1.4.20-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fcd84e4d46a86291495d131a7824ba38d2e8278bda9425c50661a04633174319"},
-    {file = "SQLAlchemy-1.4.20-cp37-cp37m-win32.whl", hash = "sha256:2f60a2e599cf5cf5e5327ce60f2918b897e42ad9f405d10dd01e37869c0ce6fc"},
-    {file = "SQLAlchemy-1.4.20-cp37-cp37m-win_amd64.whl", hash = "sha256:f6fc526bd70898489d02bf52c8f0632ab377592ae954d0c0a5bb38d618dddaa9"},
-    {file = "SQLAlchemy-1.4.20-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:25c0e0f3a7e8c19350086b3c0fe93c4def045cec053d749ef15da710c4d54c81"},
-    {file = "SQLAlchemy-1.4.20-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e0d48456e1aa4f0537f9c9af7be71e1f0659ff68bc1cd538ebc785f6b007bd0d"},
-    {file = "SQLAlchemy-1.4.20-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9675d5bc7e4f96a7bb2b54d14e9b269a5fb6e5d36ecc7d01f0f65bb9af3185f9"},
-    {file = "SQLAlchemy-1.4.20-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b502b5e2f08500cc4b8d29bfc4f51d805adcbc00f8d149e98fda8aae85ddb644"},
-    {file = "SQLAlchemy-1.4.20-cp38-cp38-win32.whl", hash = "sha256:aad3234a41340e9cf6184e621694e2a7233ba3f8aef9b1e6de8cba431b45ebd2"},
-    {file = "SQLAlchemy-1.4.20-cp38-cp38-win_amd64.whl", hash = "sha256:6c8406c3d8c1c7d15da454de15d77f7bb48d14ede5db994f74226c348cf1050e"},
-    {file = "SQLAlchemy-1.4.20-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:238d78b3110b7f7cffdb70bf9cda686e0d876a849bc78ba4d471aa7b1461f306"},
-    {file = "SQLAlchemy-1.4.20-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:854a7b15750e617e16f8d65dbc004f065a7963544b253b923f16109557648777"},
-    {file = "SQLAlchemy-1.4.20-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ff38ecf89c69a531a7326c2dae71982edfe2f805f3c016cdc5bfd1a04ebf80cb"},
-    {file = "SQLAlchemy-1.4.20-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86c079732328f1add097b0b8079cd532b5d28e207fac93e9d6ea5f487506deef"},
-    {file = "SQLAlchemy-1.4.20-cp39-cp39-win32.whl", hash = "sha256:46b99eab618cdc1c871ea707b7c52edc23cfea6c750740cd242ba62b5c84de7f"},
-    {file = "SQLAlchemy-1.4.20-cp39-cp39-win_amd64.whl", hash = "sha256:b86d83fefc8a8c394f3490c37e1953bc16c311a3d1d1cf91518793bfb9847fb4"},
-    {file = "SQLAlchemy-1.4.20.tar.gz", hash = "sha256:38ee3a266afef2978e82824650457f70c5d74ec0cadec1b10fe5ed6f038eb5d0"},
+    {file = "SQLAlchemy-1.4.22-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:488608953385d6c127d2dcbc4b11f8d7f2f30b89f6bd27c01b042253d985cc2f"},
+    {file = "SQLAlchemy-1.4.22-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:5d856cc50fd26fc8dd04892ed5a5a3d7eeb914fea2c2e484183e2d84c14926e0"},
+    {file = "SQLAlchemy-1.4.22-cp27-cp27m-win32.whl", hash = "sha256:a00d9c6d3a8afe1d1681cd8a5266d2f0ed684b0b44bada2ca82403b9e8b25d39"},
+    {file = "SQLAlchemy-1.4.22-cp27-cp27m-win_amd64.whl", hash = "sha256:5908ea6c652a050d768580d01219c98c071e71910ab8e7b42c02af4010608397"},
+    {file = "SQLAlchemy-1.4.22-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b7fb937c720847879c7402fe300cfdb2aeff22349fa4ea3651bca4e2d6555939"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:9bfe882d5a1bbde0245dca0bd48da0976bd6634cf2041d2fdf0417c5463e40e5"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eedd76f135461cf237534a6dc0d1e0f6bb88a1dc193678fab48a11d223462da5"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6a16c7c4452293da5143afa3056680db2d187b380b3ef4d470d4e29885720de3"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44d23ea797a5e0be71bc5454b9ae99158ea0edc79e2393c6e9a2354de88329c0"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-win32.whl", hash = "sha256:a5e14cb0c0a4ac095395f24575a0e7ab5d1be27f5f9347f1762f21505e3ba9f1"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-win_amd64.whl", hash = "sha256:bc34a007e604091ca3a4a057525efc4cefd2b7fe970f44d20b9cfa109ab1bddb"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:756f5d2f5b92d27450167247fb574b09c4cd192a3f8c2e493b3e518a204ee543"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fcbb4b4756b250ed19adc5e28c005b8ed56fdb5c21efa24c6822c0575b4964d"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:09dbb4bc01a734ccddbf188deb2a69aede4b3c153a72b6d5c6900be7fb2945b1"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f028ef6a1d828bc754852a022b2160e036202ac8658a6c7d34875aafd14a9a15"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-win32.whl", hash = "sha256:68393d3fd31469845b6ba11f5b4209edbea0b58506be0e077aafbf9aa2e21e11"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-win_amd64.whl", hash = "sha256:891927a49b2363a4199763a9d436d97b0b42c65922a4ea09025600b81a00d17e"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:fd2102a8f8a659522719ed73865dff3d3cc76eb0833039dc473e0ad3041d04be"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4014978de28163cd8027434916a92d0f5bb1a3a38dff5e8bf8bff4d9372a9117"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f814d80844969b0d22ea63663da4de5ca1c434cfbae226188901e5d368792c17"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d09a760b0a045b4d799102ae7965b5491ccf102123f14b2a8cc6c01d1021a2d9"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-win32.whl", hash = "sha256:26daa429f039e29b1e523bf763bfab17490556b974c77b5ca7acb545b9230e9a"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-win_amd64.whl", hash = "sha256:12bac5fa1a6ea870bdccb96fe01610641dd44ebe001ed91ef7fcd980e9702db5"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:39b5d36ab71f73c068cdcf70c38075511de73616e6c7fdd112d6268c2704d9f5"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5102b9face693e8b2db3b2539c7e1a5d9a5b4dc0d79967670626ffd2f710d6e6"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c9373ef67a127799027091fa53449125351a8c943ddaa97bec4e99271dbb21f4"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:36a089dc604032d41343d86290ce85d4e6886012eea73faa88001260abf5ff81"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-win32.whl", hash = "sha256:b48148ceedfb55f764562e04c00539bb9ea72bf07820ca15a594a9a049ff6b0e"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-win_amd64.whl", hash = "sha256:1fdae7d980a2fa617d119d0dc13ecb5c23cc63a8b04ffcb5298f2c59d86851e9"},
+    {file = "SQLAlchemy-1.4.22.tar.gz", hash = "sha256:ec1be26cdccd60d180359a527d5980d959a26269a2c7b1b327a1eea0cab37ed8"},
 ]
 sqlalchemy-stubs = [
     {file = "sqlalchemy-stubs-0.3.tar.gz", hash = "sha256:a3318c810697164e8c818aa2d90bac570c1a0e752ced3ec25455b309c0bee8fd"},
@@ -2373,6 +1553,10 @@ toastedmarshmallow = [
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomli = [
+    {file = "tomli-1.1.0-py3-none-any.whl", hash = "sha256:f4a182048010e89cbec0ae4686b21f550a7f2903f665e34a6de58ec15424f919"},
+    {file = "tomli-1.1.0.tar.gz", hash = "sha256:33d7984738f8bb699c9b0a816eb646a8178a69eaa792d258486776a5d21b8ca5"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
@@ -2406,349 +1590,6 @@ typed-ast = [
     {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
-types-aiofiles = [
-    {file = "types-aiofiles-0.1.7.tar.gz", hash = "sha256:e5364aed6bcc784e62cbed396b712290cbac349b3f7d41fde6f0681eff9b38d2"},
-    {file = "types_aiofiles-0.1.7-py3-none-any.whl", hash = "sha256:227c0bab8cd956b9f2002127d5e97628a555b0939628cc960127c26d9fde7805"},
-]
-types-all = [
-    {file = "types_all-1.0.0-py2.py3-none-any.whl", hash = "sha256:5de4a3c9f9c5687978fd05c3bc08e6b70b0c4c093a50e3ef866bbe50c5534a68"},
-    {file = "types_all-1.0.0.tar.gz", hash = "sha256:b61d204c31b733e4296e666399c0ecf829844ab7080d77e5404fa55ef1d7d972"},
-]
-types-annoy = [
-    {file = "types-annoy-1.17.2.tar.gz", hash = "sha256:cfbdfe9228a8ef6e301e90cde0b8592758302cf5edeb7966bcb3a49cde7da245"},
-    {file = "types_annoy-1.17.2-py2.py3-none-any.whl", hash = "sha256:7a937320b240b19dd5ed41387fd31c3e89190d42029e3be85fd090eaa77c81c1"},
-]
-types-atomicwrites = [
-    {file = "types-atomicwrites-0.1.5.tar.gz", hash = "sha256:778d6ab2d188ac41d08f62a1f671b003af57ae1feba208b59433272d5ac1202a"},
-    {file = "types_atomicwrites-0.1.5-py2.py3-none-any.whl", hash = "sha256:9b73ac447ce007329575d3684d756fc636c89d8652b3bbd9e289953de15c88e7"},
-]
-types-backports = [
-    {file = "types-backports-0.1.3.tar.gz", hash = "sha256:f4b7206c073df88d6200891e3d27506185fd60cda66fb289737b2fa92c0010cf"},
-    {file = "types_backports-0.1.3-py2.py3-none-any.whl", hash = "sha256:dafcd61848081503e738a7768872d1dd6c018401b4d2a1cfb608ea87ec9864b9"},
-]
-types-backports-abc = [
-    {file = "types-backports_abc-0.1.4.tar.gz", hash = "sha256:4b94b6761171ebc68dc894738792ba602de7a100230396d0f751a44104981479"},
-    {file = "types_backports_abc-0.1.4-py2.py3-none-any.whl", hash = "sha256:101f230f0f7995b4d781fb27623a3543d138b899dc1667d3ca33636255edcb4a"},
-]
-types-bleach = [
-    {file = "types-bleach-3.3.3.tar.gz", hash = "sha256:431db47fb76a2e47d2fe076136dc591ab7c73db47511519718f0bd5db83eb3b4"},
-    {file = "types_bleach-3.3.3-py2.py3-none-any.whl", hash = "sha256:73f684ffb17d21db3f062363b144c3506c951c1107e0f562c2476413013436a9"},
-]
-types-boto = [
-    {file = "types-boto-0.1.2.tar.gz", hash = "sha256:deb707cb39212f2f5d3c53341ceb40f6d3b312b549e706603a101c4949f3399c"},
-    {file = "types_boto-0.1.2-py2.py3-none-any.whl", hash = "sha256:ced3bc0b00fd39f55fc721b14cab2ac9a1b632501c647b98fef837d59be0b430"},
-]
-types-cachetools = [
-    {file = "types-cachetools-0.1.9.tar.gz", hash = "sha256:cfcb41a71d5dab7b785fa3adeb367fa7584062c4d74e6d91ac72538a349b5f7b"},
-    {file = "types_cachetools-0.1.9-py3-none-any.whl", hash = "sha256:c3fa1afdfdeaf3cdc396ad5518ef3e6984f73092be61b525708f23f527aea51d"},
-]
-types-certifi = [
-    {file = "types-certifi-0.1.4.tar.gz", hash = "sha256:7c134d978f15e4aa2d2b1a85b2a92241ed6b256c3452511b7783b6a28b304b71"},
-    {file = "types_certifi-0.1.4-py2.py3-none-any.whl", hash = "sha256:afe4d94726491d843f10e5746797689ea5dcbd78454a653be47d72a8c8ce3bed"},
-]
-types-characteristic = [
-    {file = "types-characteristic-0.1.3.tar.gz", hash = "sha256:2cd9aca1c0d24bae96b42a4539166d91ba2c530cf4a8698d6766268e2960fbf2"},
-    {file = "types_characteristic-0.1.3-py2.py3-none-any.whl", hash = "sha256:6142cdaea930eab6853f0a02c4facb70b292e10612698b58dba0cbe2c8642a11"},
-]
-types-chardet = [
-    {file = "types-chardet-0.1.3.tar.gz", hash = "sha256:f9e6dfa655a2a7228e8128ef0f70a8b77f1176514ec2c055ca414ee883af1246"},
-    {file = "types_chardet-0.1.3-py2.py3-none-any.whl", hash = "sha256:6927c7ed3d477f51fbea5c708d79f9b13183b2fc229ca837ca1cdc1f4c43d699"},
-]
-types-click = [
-    {file = "types-click-7.1.2.tar.gz", hash = "sha256:040897284e4f9466825c3865f708a985a8e7ba4d8e22cb9198ffb7b522160850"},
-    {file = "types_click-7.1.2-py2.py3-none-any.whl", hash = "sha256:4722746f1ec9fd3fc8b1d7fb8c840604dc22f9e32bcc7a31a36d6d85cc2bce24"},
-]
-types-click-spinner = [
-    {file = "types-click-spinner-0.1.4.tar.gz", hash = "sha256:f1620fc24623031adb5a56cdc1a4094a69d6138f7a964930a6ea87dc4d6f21a1"},
-    {file = "types_click_spinner-0.1.4-py2.py3-none-any.whl", hash = "sha256:7838c2a38bfaa36ec7c91f31a80fcf218469c06597f9dcbbaeed5091482d2de4"},
-]
-types-colorama = [
-    {file = "types-colorama-0.4.2.tar.gz", hash = "sha256:ae4f7fcb533e529c182b934423b0c589452ec8b3470430b2ee7baf06cb7f4a8d"},
-    {file = "types_colorama-0.4.2-py2.py3-none-any.whl", hash = "sha256:42bd280fad509c698e1485f9658493076d315d189a5014be843dffee2d264902"},
-]
-types-contextvars = [
-    {file = "types-contextvars-0.1.4.tar.gz", hash = "sha256:427fa5e9f00859de653a1f5dfe91c6f2283325f4a2893fca56ff1c473b3d7cf5"},
-    {file = "types_contextvars-0.1.4-py2.py3-none-any.whl", hash = "sha256:d3327970cdcf3b7d8b89e693c091ab0bc0b804246a100f7a5d8a86d5622780a0"},
-]
-types-croniter = [
-    {file = "types-croniter-0.1.4.tar.gz", hash = "sha256:7eb0eba21b45114e901a2a685ba8a162d7014d3e06365083a7b39c193c1ef45c"},
-    {file = "types_croniter-0.1.4-py2.py3-none-any.whl", hash = "sha256:c0ec4205a6e2d1723d3d9c163e649e976accb4218a082855c68fcee875bbb720"},
-]
-types-cryptography = [
-    {file = "types-cryptography-3.3.3.tar.gz", hash = "sha256:de2b12e971023b25bd96b7da251dc747ea5b4670a998f9160153d96e4f918f0b"},
-    {file = "types_cryptography-3.3.3-py2.py3-none-any.whl", hash = "sha256:524afedb2e7f3fa4b22bd164efb82809a75ff960cc5d40a2fa9b7c2cda228fab"},
-]
-types-dataclasses = [
-    {file = "types-dataclasses-0.1.5.tar.gz", hash = "sha256:7b5f4099fb21c209f2df3a83c2b64308c29955769d610a457244dc0eebe1cafc"},
-    {file = "types_dataclasses-0.1.5-py2.py3-none-any.whl", hash = "sha256:c19491cfb981bff9cafd9c113c291a7a54adccc6298ded8ca3de0d7abe211984"},
-]
-types-dateparser = [
-    {file = "types-dateparser-0.1.3.tar.gz", hash = "sha256:bbb0c199bbfc0f8f811eb0c5e6bf80ff68dd15bf30f3e7ee68411f6106e3209b"},
-    {file = "types_dateparser-0.1.3-py2.py3-none-any.whl", hash = "sha256:f96df44c5fa6d71a9c0a5523fb8f1109b5844c19d5a9beb7b20868a68a20ede0"},
-]
-types-datetimerange = [
-    {file = "types-DateTimeRange-0.1.2.tar.gz", hash = "sha256:d0154a5ed968b97ff66ca16e295c9eadd39bf67fc490cd9eb714ecda09496da7"},
-    {file = "types_DateTimeRange-0.1.2-py2.py3-none-any.whl", hash = "sha256:0da96620b7d16eae61e41d9501ec6b4888589464ff5d7fa92d7132108a21ded0"},
-]
-types-decorator = [
-    {file = "types-decorator-0.1.5.tar.gz", hash = "sha256:88c8f0f4229124f7bea7cbd968dea48aebbfb0144f0b50c0ec810fe18916cf65"},
-    {file = "types_decorator-0.1.5-py2.py3-none-any.whl", hash = "sha256:76045ca8ccb4cf2a2ccbaa36d02a75f4ec07af334036771af0a0b0ea0503d4a9"},
-]
-types-deprecated = [
-    {file = "types-Deprecated-0.1.3.tar.gz", hash = "sha256:b1d32e0faa954af93cf8fb2a4309c3a7d09b0e7f4a77957f41156b1724d19dc2"},
-    {file = "types_Deprecated-0.1.3-py2.py3-none-any.whl", hash = "sha256:e2b0f2b28a07e3d4dd8d04b9f153056906ab9313b7da9f6716bb2c1c485d4624"},
-]
-types-docopt = [
-    {file = "types-docopt-0.6.2.tar.gz", hash = "sha256:647874c49fd8c9cecf8977b5102f3968cae5c0df64f11127d0745cdc64a9e51c"},
-    {file = "types_docopt-0.6.2-py2.py3-none-any.whl", hash = "sha256:34b9b66dbddffc596f4cf70ddd40c1248c2b65c81ca460eaf902f5a147f68fb1"},
-]
-types-docutils = [
-    {file = "types-docutils-0.1.7.tar.gz", hash = "sha256:241b901395b4da05de39fe4aa364acc55536029e51308e11673f51e74e861645"},
-    {file = "types_docutils-0.1.7-py2.py3-none-any.whl", hash = "sha256:61f1e12f3b090c28979338830f122d5bfc1a2287156a8c384b6142ce6d0aa8ec"},
-]
-types-emoji = [
-    {file = "types-emoji-1.2.2.tar.gz", hash = "sha256:6d8f26809f41dbbbd3c7604415eba29a06edbc665784fd63fe2fd706729aacec"},
-    {file = "types_emoji-1.2.2-py2.py3-none-any.whl", hash = "sha256:e10ca236f4e5da74e1f7881ca8c768de8d18f714c8118755328263f321168bd8"},
-]
-types-enum34 = [
-    {file = "types-enum34-0.1.8.tar.gz", hash = "sha256:9e91a94f1f42c73bd7aa43f19a157d722522d29097f301748a034e08693a423d"},
-    {file = "types_enum34-0.1.8-py3-none-any.whl", hash = "sha256:5833cfd003d7a860e8442d04a06aaa2bef1f050933f844fa7bd3634914e1aa7f"},
-]
-types-fb303 = [
-    {file = "types-fb303-0.1.6.tar.gz", hash = "sha256:2dc85a814e3c85da5d4d345efbc6ab0d804c6a1d4beb1a219c2a7381e2842286"},
-    {file = "types_fb303-0.1.6-py3-none-any.whl", hash = "sha256:cfb004c174756d078b5f2a53154290f9529b8e73f3c54ec23e8426013bc5532f"},
-]
-types-filelock = [
-    {file = "types-filelock-0.1.4.tar.gz", hash = "sha256:f73f0e9637cb5a39aec57542d359df826e7b910cb87e1f7902275c91fb5466b6"},
-    {file = "types_filelock-0.1.4-py2.py3-none-any.whl", hash = "sha256:ce002b38659eb64f0338c02a025078f52c550e5da4ca5c10a70c1adf4b8d19fa"},
-]
-types-first = [
-    {file = "types-first-0.1.5.tar.gz", hash = "sha256:82f7553489fcc16a031132f9be8401b4d0be11fd3f35a4f61edb6c1153f93ddf"},
-    {file = "types_first-0.1.5-py2.py3-none-any.whl", hash = "sha256:6e7465c0c09951d07e00d845474edf2ad0b4a27f4e7ea34394c8d77243e35e88"},
-]
-types-flask = [
-    {file = "types-Flask-1.1.1.tar.gz", hash = "sha256:90afe8bd050cf8830cdc620bb9aa4471836b86af88e4d33fccc8789242a661e2"},
-    {file = "types_Flask-1.1.1-py2.py3-none-any.whl", hash = "sha256:4885fd9c64756b0901d3de0a197d0ede60df114d0fbab500aa1bd73bb2c1651c"},
-]
-types-freezegun = [
-    {file = "types-freezegun-0.1.4.tar.gz", hash = "sha256:4b4a391598af0c5695d56f6af7ac36faf2a757e3f50046a2e95b3a01ba889fcd"},
-    {file = "types_freezegun-0.1.4-py2.py3-none-any.whl", hash = "sha256:e90a30b16daf3ca0758c2bce53f47ea7d2e8520f14c28a3dc6108bcb67bb7525"},
-]
-types-frozendict = [
-    {file = "types-frozendict-0.1.5.tar.gz", hash = "sha256:fa5e6a24adfe23db1e37c5f571bca5dda4c0ab388ec03462e498ed22c2449494"},
-    {file = "types_frozendict-0.1.5-py2.py3-none-any.whl", hash = "sha256:9e08c9593d6a20b13411fcf4e7597dbae896d06afaf664c7759dee5cb180d969"},
-]
-types-futures = [
-    {file = "types-futures-0.1.6.tar.gz", hash = "sha256:da372dd55dc08c257de1e3dfd56273e44af9668e077047b0509adcfc43dd2838"},
-    {file = "types_futures-0.1.6-py3-none-any.whl", hash = "sha256:7cb32c3fb4885089d78873a28ad33db3d5300661eac8b3ad327f4f5616fdf742"},
-]
-types-geoip2 = [
-    {file = "types-geoip2-0.1.2.tar.gz", hash = "sha256:2a62031c9bb0916f05ad7ed8d3dd4d51243658385177256a5460625786bf3885"},
-    {file = "types_geoip2-0.1.2-py2.py3-none-any.whl", hash = "sha256:90be79d7ec742d14310266bb4c32f154ac14c488b0e60338b78aa3871d7cc886"},
-]
-types-ipaddress = [
-    {file = "types-ipaddress-0.1.5.tar.gz", hash = "sha256:ffa2c4fe2e8f51898465e2142d4d325fbab009aaa7822db20a4e2e3a896560d7"},
-    {file = "types_ipaddress-0.1.5-py3-none-any.whl", hash = "sha256:137ab8a5a895a48157438c8f3eea738e2c22e82c1114ab20ffd78c8637bbc008"},
-]
-types-itsdangerous = [
-    {file = "types-itsdangerous-1.1.2.tar.gz", hash = "sha256:f9817850bc7f0caecf4301fa17395ee3685e6afd3a4aea73156df3508e1177bb"},
-    {file = "types_itsdangerous-1.1.2-py2.py3-none-any.whl", hash = "sha256:52b44e2a80bb456c70961c5fb24b5299b2e1239d8740dc8b611c20f0ea7af6e4"},
-]
-types-jack-client = [
-    {file = "types-JACK-Client-0.1.5.tar.gz", hash = "sha256:0a9524b20d361f2adec9a646f4c9e217c89acb3795463b24b1394acb46f9962c"},
-    {file = "types_JACK_Client-0.1.5-py2.py3-none-any.whl", hash = "sha256:c09c246a04c853f217db37b2843812c5646669bc80d8e4fdaf50344a58267670"},
-]
-types-jinja2 = [
-    {file = "types-Jinja2-2.11.2.tar.gz", hash = "sha256:5b53d2b8bc6dd6dfbc0ae3e33e346fbe343cbeba1ed528858749e2a2ffe0e143"},
-    {file = "types_Jinja2-2.11.2-py2.py3-none-any.whl", hash = "sha256:d27e112a8add449407de235f4533239149056327c8bddc6b0d6bf80cd7280c16"},
-]
-types-kazoo = [
-    {file = "types-kazoo-0.1.3.tar.gz", hash = "sha256:97a3b95e2437fcc093506e822b009c1ee9e4db6906631b5320117f0d2be4aa4a"},
-    {file = "types_kazoo-0.1.3-py3-none-any.whl", hash = "sha256:885cb481b2af327f6ecae725c9e2770ece454c675b94ea5e367dbc76243e7418"},
-]
-types-markdown = [
-    {file = "types-Markdown-3.3.0.tar.gz", hash = "sha256:b7bf9ce52a9f712c6a59b75350ed435d6fc1f1d5eafed44a321472bf96cf77db"},
-    {file = "types_Markdown-3.3.0-py3-none-any.whl", hash = "sha256:cc18cc0fcc2ba8ab3f5233b2945db33e2e68ddad179708b2d2f08da08d33bc4e"},
-]
-types-markupsafe = [
-    {file = "types-MarkupSafe-1.1.4.tar.gz", hash = "sha256:4fd2cc858fb4aea38555850f4ac2ecafae3543c88abb056669a3346c5c1b202c"},
-    {file = "types_MarkupSafe-1.1.4-py3-none-any.whl", hash = "sha256:2539a9e9b1b5a1bf1c10fdf2cb1dcb89e6f360759196883f4d5d103c53624375"},
-]
-types-maxminddb = [
-    {file = "types-maxminddb-0.1.2.tar.gz", hash = "sha256:debf4605e18390d3a38e8c92d383288fbb529c48fb594acffe6a8253c8df5d1a"},
-    {file = "types_maxminddb-0.1.2-py2.py3-none-any.whl", hash = "sha256:16e616a188efcebfdd6208321a6c7d747e976e7b8a316c67f19992139d46104c"},
-]
-types-mock = [
-    {file = "types-mock-0.1.3.tar.gz", hash = "sha256:9bdafab236c0530fed36dbf18bc942633b2033bfda16551b2e4eb767341a8b8c"},
-    {file = "types_mock-0.1.3-py2.py3-none-any.whl", hash = "sha256:e052879bb0a7d78547cce3342ffdf4ec3e8d2eff8f237911c3c8e31ac7ea8c86"},
-]
-types-mypy-extensions = [
-    {file = "types-mypy-extensions-0.4.5.tar.gz", hash = "sha256:b34f184f09fd789e7673e2f8bbe4bf37b18cd4eb455fbec2f5d1c536d5b059a4"},
-    {file = "types_mypy_extensions-0.4.5-py2.py3-none-any.whl", hash = "sha256:479798a2c169394cff9d5407d03844c3478b73d01de81810128e1109223965a4"},
-]
-types-nmap = [
-    {file = "types-nmap-0.1.4.tar.gz", hash = "sha256:82e146fe34106fb1bff7108e854be1ebc9cc715e676db4f152844677c485968b"},
-    {file = "types_nmap-0.1.4-py2.py3-none-any.whl", hash = "sha256:5d726b114dc9b8226f9791c5dfb81e93c28b9b5aff0e6b6b366568263c0ed394"},
-]
-types-openssl-python = [
-    {file = "types_openssl_python-0.1.3-py2.py3-none-any.whl", hash = "sha256:8f58ebae880550412f8aad619a7615e49471de2766dfc35aa7faa5609d01ffe5"},
-]
-types-orjson = [
-    {file = "types-orjson-0.1.1.tar.gz", hash = "sha256:7454bfbaed27900a844bb9d8e211b69f1c335f0b9e3541d4950a793db41c104d"},
-    {file = "types_orjson-0.1.1-py2.py3-none-any.whl", hash = "sha256:92f85986261ea1a5cb215e4b35e4016631d35163a372f023918750f340ea737f"},
-]
-types-paramiko = [
-    {file = "types-paramiko-0.1.7.tar.gz", hash = "sha256:51ce59aea222c47d0590e2b8d8cefbc5aeb469d8bf6368e4f06ad3c61c932c72"},
-    {file = "types_paramiko-0.1.7-py2.py3-none-any.whl", hash = "sha256:9fb9f3a363c99ae735148a7ce3c28adbe8f87797ec3c8cce3103899acbdebfa8"},
-]
-types-pathlib2 = [
-    {file = "types-pathlib2-2.2.0.tar.gz", hash = "sha256:36a574ac953208372df7f94c6f2bf1ba8c9b79e31023fe5440f96c57351a19b5"},
-    {file = "types_pathlib2-2.2.0-py3-none-any.whl", hash = "sha256:198b2f6795067661d32f00c1bc1b6689ec2d664a029462fd3c208433b1fb2898"},
-]
-types-pillow = [
-    {file = "types-Pillow-8.3.1.tar.gz", hash = "sha256:12329f4700941f60a0054194815b4bf674e5dfac73debd97ef7548c51f2c5103"},
-    {file = "types_Pillow-8.3.1-py3-none-any.whl", hash = "sha256:9556ba9cb25f570371bd082dc30fe77a549a22bac035ce9d3a606bfc541d12ec"},
-]
-types-pkg-resources = [
-    {file = "types-pkg_resources-0.1.3.tar.gz", hash = "sha256:834a9b8d3dbea343562fd99d5d3359a726f6bf9d3733bccd2b4f3096fbab9dae"},
-    {file = "types_pkg_resources-0.1.3-py2.py3-none-any.whl", hash = "sha256:0cb9972cee992249f93fff1a491bf2dc3ce674e5a1926e27d4f0866f7d9b6d9c"},
-]
-types-polib = [
-    {file = "types-polib-1.1.1.tar.gz", hash = "sha256:1689820c1644080506ce30441c82eba931cae4f1133973030398cdc3164a4832"},
-    {file = "types_polib-1.1.1-py3-none-any.whl", hash = "sha256:319c60b02236228c7ef4f1c937b0b39e7364812195dacf1cb02d802a9a54f5c4"},
-]
-types-protobuf = [
-    {file = "types-protobuf-3.17.0.tar.gz", hash = "sha256:00f6c405c67f0144b92e0baab6610c4d4356c2927ee86f77aa71ac2a8648cb8a"},
-    {file = "types_protobuf-3.17.0-py3-none-any.whl", hash = "sha256:dd7df3487c1dc9011653472d3bc7dd486c6b73151707fda12cdef30a0501fd1e"},
-]
-types-pyaudio = [
-    {file = "types-pyaudio-0.2.2.tar.gz", hash = "sha256:90650b96f513f1c31dac1870e56a8db67e9b0ecd23db876f3ea0ae96f684abe0"},
-    {file = "types_pyaudio-0.2.2-py2.py3-none-any.whl", hash = "sha256:0ea6852eeab934802795e8f5ce112192b0b95ea88fc8988870fba032c68043c8"},
-]
-types-pycurl = [
-    {file = "types-pycurl-0.1.3.tar.gz", hash = "sha256:a125d5c7dc5dd98dcf3611fca315b451ad89c8fedf800f4c035193123eb30f85"},
-    {file = "types_pycurl-0.1.3-py2.py3-none-any.whl", hash = "sha256:fab2aa57cee019e484eabba4b16d35934b72ac87366ff8e9006867b95ea51f4c"},
-]
-types-pyfarmhash = [
-    {file = "types-pyfarmhash-0.2.1.tar.gz", hash = "sha256:c9fe7f5bf5002d7453e72b03bd8ce0dd3d8bd70223d783abce547758cd72cb6b"},
-    {file = "types_pyfarmhash-0.2.1-py2.py3-none-any.whl", hash = "sha256:4038decaac51c36c2c8cb9b5e11b149b825a1c1897098563e7a49be034f0658c"},
-]
-types-pyjwt = [
-    {file = "types-PyJWT-1.7.1.tar.gz", hash = "sha256:99c1a0d94d370951f9c6e57b1c369be280b2cbfab72c0f9c0998707490f015c9"},
-    {file = "types_PyJWT-1.7.1-py2.py3-none-any.whl", hash = "sha256:810112a84b6c060bb5bc1959a1d229830465eccffa91d8a68eeaac28fb7713ac"},
-]
-types-pymssql = [
-    {file = "types-pymssql-0.1.4.tar.gz", hash = "sha256:26c52c01d867bfbda1e1ddb3aec25b5372a702d6f0e82e604f014635e7d9920c"},
-    {file = "types_pymssql-0.1.4-py3-none-any.whl", hash = "sha256:260b45d3af54f7e4020cc55e0c198974479d1e53e55d48142af06e827c313538"},
-]
-types-pymysql = [
-    {file = "types-PyMySQL-1.0.0.tar.gz", hash = "sha256:528f1602a54fc0ba9bc6ebe6b6f756c33e9a8ed4dfbf1cad05f4b9781f43886d"},
-    {file = "types_PyMySQL-1.0.0-py2.py3-none-any.whl", hash = "sha256:32e0e966140954803ed03a9b740fae08dfee8a9a299f2b2b7951bb6754eade19"},
-]
-types-pyrfc3339 = [
-    {file = "types-pyRFC3339-0.1.1.tar.gz", hash = "sha256:80569ea7c6a97f4b5f46e4db26b8a7c0beac3a117f5e74b33a6190275c999e4d"},
-    {file = "types_pyRFC3339-0.1.1-py2.py3-none-any.whl", hash = "sha256:9632e221a33f96304dc654c7a43ea986995d9b0acf8fad6714baa40962ee4089"},
-]
-types-pysftp = [
-    {file = "types-pysftp-0.2.2.tar.gz", hash = "sha256:ea0a2a3eafb112f95481676d33c75c308c712ad24080ea439114017f4f9528ea"},
-    {file = "types_pysftp-0.2.2-py2.py3-none-any.whl", hash = "sha256:88148e80a46070f4358f1a37fb06b57851f26f21b3ceae32b030456db8e85db7"},
-]
-types-python-dateutil = [
-    {file = "types-python-dateutil-0.1.4.tar.gz", hash = "sha256:e6486ca27b6dde73e0ec079a9e1b03e208766e6bc7f1e08964a7e9104a5c7d7a"},
-    {file = "types_python_dateutil-0.1.4-py2.py3-none-any.whl", hash = "sha256:39bfe0bde61fc673b8fa28167bd78622d976210f791971b9f3e10877cbf119a4"},
-]
-types-python-gflags = [
-    {file = "types-python-gflags-0.1.2.tar.gz", hash = "sha256:e408179c5e2edd69a85d1fffb2f052ae17dc837ab939f8462cdef36f689a5b44"},
-    {file = "types_python_gflags-0.1.2-py2.py3-none-any.whl", hash = "sha256:e8eb02892afac83e9827f501da14805bcae92c1dfb7c568f914b1c8f3b4f9bb8"},
-]
-types-python-slugify = [
-    {file = "types-python-slugify-0.1.1.tar.gz", hash = "sha256:98dd5a5fcc1d37d2d05698ca744c808e2fb1cac8aa1b1a43e0430d2dd25392c5"},
-    {file = "types_python_slugify-0.1.1-py2.py3-none-any.whl", hash = "sha256:16f0c1dc95c385bc9770feb357e322e7f53440fe87e7ea941fb54bbe7a84d4df"},
-]
-types-pytz = [
-    {file = "types-pytz-2021.1.0.tar.gz", hash = "sha256:addfa2a1a27b324b6beb422faa4737962532bbab3793481d5bdebbffb8f9f243"},
-    {file = "types_pytz-2021.1.0-py3-none-any.whl", hash = "sha256:ec9555397f91518b2cf028ed837a69e388763c6a5e58abffaf37732f9c581a46"},
-]
-types-pyvmomi = [
-    {file = "types-pyvmomi-0.1.2.tar.gz", hash = "sha256:505513fa265d43d64ca2a1bad7d3f08f162a46141c9f8b48d3eb4d69fc6d78e1"},
-    {file = "types_pyvmomi-0.1.2-py2.py3-none-any.whl", hash = "sha256:6f2079ba312ae2cdc9489a656f1df0d40dfd7598a380d257aaa5a827bfbff35a"},
-]
-types-pyyaml = [
-    {file = "types-PyYAML-5.4.3.tar.gz", hash = "sha256:2e7b81b2b7af751634425107b986086c6ba7cb61270a43a5c290c58be8cdbc3a"},
-    {file = "types_PyYAML-5.4.3-py2.py3-none-any.whl", hash = "sha256:bca83cbfc0be48600a8abf1e3d87fb762a91e6d35d724029a3321dd2dce2ceb1"},
-]
-types-redis = [
-    {file = "types-redis-3.5.4.tar.gz", hash = "sha256:936e98f9090c11610f4f5171d2ca8fa5c5eab842422b3cc2f9355f57d01e1a6b"},
-    {file = "types_redis-3.5.4-py3-none-any.whl", hash = "sha256:954feb1f573216b215c1d564c1b27091a7ce8b7fd3af9474d9e88d4081881aff"},
-]
-types-requests = [
-    {file = "types-requests-2.25.0.tar.gz", hash = "sha256:ee0d0c507210141b7d5b8639cc43eaa726084178775db2a5fb06fbf85c185808"},
-    {file = "types_requests-2.25.0-py3-none-any.whl", hash = "sha256:fa5c1e5e832ff6193507d8da7e1159281383908ee193a2f4b37bc08140b51844"},
-]
-types-retry = [
-    {file = "types-retry-0.1.3.tar.gz", hash = "sha256:a81397633b3a5c621c01975919e43a11301fb854f6af66088f783b8cd4473f53"},
-    {file = "types_retry-0.1.3-py2.py3-none-any.whl", hash = "sha256:9ff6a3570f7fbe42c6580c8a422c191453bfa16a46e346003b5990e0bc03da40"},
-]
-types-routes = [
-    {file = "types-Routes-0.1.7.tar.gz", hash = "sha256:2c762baac6e31b544966bd0171b60edaffad3fd8b8670fbb0048860c1f885859"},
-    {file = "types_Routes-0.1.7-py3-none-any.whl", hash = "sha256:d844ff7cb438b862fe7f803d9158f24d41e1a4af410a5759be9b33d8093617db"},
-]
-types-scribe = [
-    {file = "types-scribe-0.1.3.tar.gz", hash = "sha256:573ae400cfd46d9b4bf4574bf7035c7969cc25c396ed0789b42e0db6e1b92e66"},
-    {file = "types_scribe-0.1.3-py3-none-any.whl", hash = "sha256:ce255505e4920b666babd91754ae07efb52d6f237235ba586a37e439fa817c98"},
-]
-types-simplejson = [
-    {file = "types-simplejson-0.1.4.tar.gz", hash = "sha256:851ae514c21b209a39d2679f865110199e37bbde5507684817c6e5ee81ca4bca"},
-    {file = "types_simplejson-0.1.4-py2.py3-none-any.whl", hash = "sha256:1318ecb45d95983e5d31c2559853032174f1646ccad00056604e6f0c98e14e1e"},
-]
-types-singledispatch = [
-    {file = "types-singledispatch-0.1.1.tar.gz", hash = "sha256:bf864ae28a67f59c8b4e25200ce330390cb943f069cb0cb49f3f6500f98ddb44"},
-    {file = "types_singledispatch-0.1.1-py2.py3-none-any.whl", hash = "sha256:9e405cd019bc1a268d768a3bad56437fc95b12a2ee49cc1a981bba703aba6dd6"},
-]
-types-six = [
-    {file = "types-six-0.1.7.tar.gz", hash = "sha256:254484e024fbef5aafd6eee80642d713e3c240e12103dbd0f41e1f602402ff35"},
-    {file = "types_six-0.1.7-py2.py3-none-any.whl", hash = "sha256:ec2b7b1bcc521b3741f9317eca8fb3bfd0e39efe427231d57b37ad40af418a5e"},
-]
-types-tabulate = [
-    {file = "types-tabulate-0.1.1.tar.gz", hash = "sha256:d1a415a8601391bc8450a669402ad57a1b620acf8d8d206fcbb3accc1440b106"},
-    {file = "types_tabulate-0.1.1-py2.py3-none-any.whl", hash = "sha256:34a4900c32a56db8c7e5a1c8857332e8d02fe45077ea0ed53a3a12a10cbdbd0c"},
-]
-types-termcolor = [
-    {file = "types-termcolor-0.1.1.tar.gz", hash = "sha256:4d9e09ce7f3267985f5280b22e25790c98cb64628b6466e1fb915dbb52ad7136"},
-    {file = "types_termcolor-0.1.1-py2.py3-none-any.whl", hash = "sha256:3694c312e32f71fdc0f469c334ea21645f3130d90c93cd53bcb06b1233e174d5"},
-]
-types-toml = [
-    {file = "types-toml-0.1.3.tar.gz", hash = "sha256:33ebe67bebaec55a123ecbaa2bd98fe588335d8d8dda2c7ac53502ef5a81a79a"},
-    {file = "types_toml-0.1.3-py2.py3-none-any.whl", hash = "sha256:d4add39a90993173d49ff0b069edd122c66ad4cf5c01082b590e380ca670ee1a"},
-]
-types-tornado = [
-    {file = "types-tornado-5.1.0.tar.gz", hash = "sha256:67c7224563a70aee0a623bc38fdb676cc77b7877d73a4a50510fb89b4221c8ac"},
-    {file = "types_tornado-5.1.0-py3-none-any.whl", hash = "sha256:5d8ef5d14aca5922ff028b635dcb04836f945b3356e5ec312eb773bc7a0fe920"},
-]
-types-typed-ast = [
-    {file = "types-typed-ast-1.4.2.tar.gz", hash = "sha256:6a47165760321835d160da20a6ac5b9065f23d6dc246162508cad1ef1238afc3"},
-    {file = "types_typed_ast-1.4.2-py2.py3-none-any.whl", hash = "sha256:014ab2742015d3eaab86ea061c27809c7e76beeb9e134102f2e2ddb34ab05c62"},
-]
-types-tzlocal = [
-    {file = "types-tzlocal-0.1.1.tar.gz", hash = "sha256:2ebbe89d0f1f8deec1d5724f400ea9bf10e87f86f4937ccb20a62183dd6ca103"},
-    {file = "types_tzlocal-0.1.1-py2.py3-none-any.whl", hash = "sha256:c2026603d3fe783eb63b0ab8d1fad13ff9df7ccc5da01bea8b4cb2bdbb8c6cef"},
-]
-types-ujson = [
-    {file = "types-ujson-0.1.1.tar.gz", hash = "sha256:92042cb7a0ba0ded003642da3367aa2a7b22a7d16ce840336b50977781526ed0"},
-    {file = "types_ujson-0.1.1-py2.py3-none-any.whl", hash = "sha256:f465118573d69c1cf570144de95c11a596abee4b48cf45c9c54abf0613d8956a"},
-]
-types-waitress = [
-    {file = "types-waitress-0.1.7.tar.gz", hash = "sha256:ef19cfaf80e4a330dd3c552847ad7525ad6ea51707c11b2c5fa9594e9b31880e"},
-    {file = "types_waitress-0.1.7-py2.py3-none-any.whl", hash = "sha256:3f498d2a5a199c91fa21b1fef86aefe9144ad2831bcb226b7e82ee660c04e4d1"},
-]
-types-werkzeug = [
-    {file = "types-Werkzeug-1.0.2.tar.gz", hash = "sha256:7f6d4c8771a67d44e83134d56e59b482bf81ebd28e6557015fdfcc81e3d11b53"},
-    {file = "types_Werkzeug-1.0.2-py2.py3-none-any.whl", hash = "sha256:1a4e551955e6fc608cf6b93a2749963b9cce5ff56cddfc90404af1c919afa937"},
-]
-types-xxhash = [
-    {file = "types-xxhash-0.1.4.tar.gz", hash = "sha256:7b8148981f01c6b517e635420d3a3ae58f9d33b72a446e5d97b511a4413da6af"},
-    {file = "types_xxhash-0.1.4-py2.py3-none-any.whl", hash = "sha256:ac3805e8f1de7401a8632e63500f8929a19096cd4a5945e0e5ec320a81c45d7c"},
-]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
     {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
@@ -2778,8 +1619,8 @@ ujson = [
     {file = "ujson-3.2.0.tar.gz", hash = "sha256:abb1996ba1c1d2faf5b1e38efa97da7f64e5373a31f705b96fe0587f5f778db4"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.5.0-py2.py3-none-any.whl", hash = "sha256:b7afa7f32abbf7dd4c24269a596cfbb0a422bb83c47215a785a7bf607cb88e1b"},
-    {file = "virtualenv-20.5.0.tar.gz", hash = "sha256:6b0e3eeb6cb081c9c81ec85633785e29edcdf6ff271d70e0d1e2bd616495c08c"},
+    {file = "virtualenv-20.6.0-py2.py3-none-any.whl", hash = "sha256:e4fc84337dce37ba34ef520bf2d4392b392999dbe47df992870dc23230f6b758"},
+    {file = "virtualenv-20.6.0.tar.gz", hash = "sha256:51df5d8a2fad5d1b13e088ff38a433475768ff61f202356bb9812c454c20ae45"},
 ]
 watchdog = [
     {file = "watchdog-2.1.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9628f3f85375a17614a2ab5eac7665f7f7be8b6b0a2a228e6f6a2e91dd4bfe26"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -973,14 +973,14 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 benchmarks = ["pytest-benchmark", "marshmallow", "toastedmarshmallow", "djangorestframework", "pydantic", "django", "pydantic", "sqlalchemy"]
 docs = ["mkdocs", "mkdocs-material", "mkdocs-awesome-pages-plugin", "pymdown-extensions"]
 json = ["ujson"]
-lint = ["mypy", "flake8", "black"]
+lint = ["mypy", "flake8", "black", "types-python-dateutil", "types-setuptools", "types-toml", "types-typed-ast", "types-ujson"]
 schema = ["fastjsonschema"]
 tests = ["fastjsonschema", "ujson", "pydantic", "sqlalchemy", "pandas", "mypy", "pytest", "pytest-cov"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "af35e20a02d1c37cf737a0c3d2af135bceef1172415abf4ee4ec797b65f98ae9"
+content-hash = "3a948ec4a00750c201f97bc39a6665f6bc16ee1c51e704d05253bf00a269a792"
 
 [metadata.files]
 appdirs = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -860,6 +860,46 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "types-python-dateutil"
+version = "0.1.4"
+description = "Typing stubs for python-dateutil"
+category = "main"
+optional = true
+python-versions = "*"
+
+[[package]]
+name = "types-setuptools"
+version = "57.0.0"
+description = "Typing stubs for setuptools"
+category = "main"
+optional = true
+python-versions = "*"
+
+[[package]]
+name = "types-toml"
+version = "0.1.3"
+description = "Typing stubs for toml"
+category = "main"
+optional = true
+python-versions = "*"
+
+[[package]]
+name = "types-typed-ast"
+version = "1.4.2"
+description = "Typing stubs for typed-ast"
+category = "main"
+optional = true
+python-versions = "*"
+
+[[package]]
+name = "types-ujson"
+version = "0.1.1"
+description = "Typing stubs for ujson"
+category = "main"
+optional = true
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "3.10.0.0"
 description = "Backported and Experimental Type Hints for Python 3.5+"
@@ -940,7 +980,7 @@ tests = ["fastjsonschema", "ujson", "pydantic", "sqlalchemy", "pandas", "mypy", 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "0f45b42a60c3b922640c601751f76ee2e8d85b11fb7b1edde432c552c5046e04"
+content-hash = "af35e20a02d1c37cf737a0c3d2af135bceef1172415abf4ee4ec797b65f98ae9"
 
 [metadata.files]
 appdirs = [
@@ -1589,6 +1629,26 @@ typed-ast = [
     {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
     {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
+]
+types-python-dateutil = [
+    {file = "types-python-dateutil-0.1.4.tar.gz", hash = "sha256:e6486ca27b6dde73e0ec079a9e1b03e208766e6bc7f1e08964a7e9104a5c7d7a"},
+    {file = "types_python_dateutil-0.1.4-py2.py3-none-any.whl", hash = "sha256:39bfe0bde61fc673b8fa28167bd78622d976210f791971b9f3e10877cbf119a4"},
+]
+types-setuptools = [
+    {file = "types-setuptools-57.0.0.tar.gz", hash = "sha256:b3ada82b21dcb8e0cafd7658d8a16018a000e55bdb7f6f3cec033223360563ce"},
+    {file = "types_setuptools-57.0.0-py3-none-any.whl", hash = "sha256:71ed0f4c71d8fb5f3026a90ae82d163c13749b110e157d82126725ac8f714360"},
+]
+types-toml = [
+    {file = "types-toml-0.1.3.tar.gz", hash = "sha256:33ebe67bebaec55a123ecbaa2bd98fe588335d8d8dda2c7ac53502ef5a81a79a"},
+    {file = "types_toml-0.1.3-py2.py3-none-any.whl", hash = "sha256:d4add39a90993173d49ff0b069edd122c66ad4cf5c01082b590e380ca670ee1a"},
+]
+types-typed-ast = [
+    {file = "types-typed-ast-1.4.2.tar.gz", hash = "sha256:6a47165760321835d160da20a6ac5b9065f23d6dc246162508cad1ef1238afc3"},
+    {file = "types_typed_ast-1.4.2-py2.py3-none-any.whl", hash = "sha256:014ab2742015d3eaab86ea061c27809c7e76beeb9e134102f2e2ddb34ab05c62"},
+]
+types-ujson = [
+    {file = "types-ujson-0.1.1.tar.gz", hash = "sha256:92042cb7a0ba0ded003642da3367aa2a7b22a7d16ce840336b50977781526ed0"},
+    {file = "types_ujson-0.1.1-py2.py3-none-any.whl", hash = "sha256:f465118573d69c1cf570144de95c11a596abee4b48cf45c9c54abf0613d8956a"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -939,8 +939,8 @@ tests = ["fastjsonschema", "ujson", "pydantic", "sqlalchemy", "pandas", "mypy", 
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.7.1"
-content-hash = "eb99b31d37e77fd8cc15ab57ac439e92607bed8368ed5b4aa3c53bc59178b217"
+python-versions = "^3.7"
+content-hash = "0f45b42a60c3b922640c601751f76ee2e8d85b11fb7b1edde432c552c5046e04"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ ujson = {version = ">=2.0", optional = true}
 # tests
 pytest = {version = "^6.2", optional = true}
 pytest-cov = {version = "^2.8", optional = true}
-pandas = {version = "^1.1.3", optional = true}
+pandas = {version = "^1.1.3", python = ">=3.7.1,<=3.9", optional = true}
 sqlalchemy = {version = "^1.3.13", optional = true}
 # benchmarks
 pytest-benchmark = {version = "^3.2", extras = ["histogram"], optional = true}
@@ -49,7 +49,6 @@ django = {version = "^2.2", optional = true}
 flake8 = {version = "^3.7.9", optional = true}
 mypy = {version = "^0.910", optional = true}
 black = {version = "^21", allow-prereleases = true, optional = true}
-types-all = {version = "^1.0.0", optional = true}
 # docs
 mkdocs = {version = "^1.1", optional = true}
 mkdocs-material = {version = "^5.5", optional = true}
@@ -77,9 +76,9 @@ mkdocs = "^1.1"
 mkdocs-material = "^5.5"
 pymdown-extensions = "^7.0"
 mkdocs-awesome-pages-plugin = "^2.2.1"
-pandas = "^1.1.3"
+# Pandas doesn't yet officially support py3.10 and installs consistently fail.
+pandas = {version = "^1.3", python = ">=3.7.1,<=3.9"}
 fastjsonschema = "^2.14.5"
-types-all = "^1.0.0"
 
 [tool.poetry.extras]
 schema = ["fastjsonschema"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,16 @@ benchmarks = [
     "pydantic",
     "sqlalchemy",
 ]
-lint = ["mypy", "flake8", "black", "types-all"]
+lint = [
+    "mypy",
+    "flake8",
+    "black",
+    "types-python-dateutil",
+    "types-setuptools",
+    "types-toml",
+    "types-typed-ast",
+    "types-ujson",
+]
 docs = [
     "mkdocs",
     "mkdocs-material",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.4.2"
+version = "2.5.0"
 description = "Typical: Python's Typing Toolkit."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,12 @@ django = {version = "^2.2", optional = true}
 flake8 = {version = "^3.7.9", optional = true}
 mypy = {version = "^0.910", optional = true}
 black = {version = "^21", allow-prereleases = true, optional = true}
+# mypy needs these....
+types-python-dateutil = {version = "*", optional = true}
+types-setuptools = {version = "*", optional = true}
+types-toml = {version = "*", optional = true}
+types-typed-ast = {version = "*", optional = true}
+types-ujson = {version = "*", optional = true}
 # docs
 mkdocs = {version = "^1.1", optional = true}
 mkdocs-material = {version = "^5.5", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Utilities",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,31 +1,31 @@
-appdirs==1.4.4 \
+appdirs==1.4.4; python_full_version >= "3.6.2" \
     --hash=sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128 \
     --hash=sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41
-atomicwrites==1.4.0; sys_platform == "win32" \
+atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.4.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") \
     --hash=sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197 \
     --hash=sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a
-attrs==21.2.0 \
+attrs==21.2.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
     --hash=sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1 \
     --hash=sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb
-backports.entry-points-selectable==1.1.0 \
+backports.entry-points-selectable==1.1.0; python_version >= "2.7" and python_full_version >= "3.6.1" \
     --hash=sha256:a6d9a871cde5e15b4c4a53e3d43ba890cc6861ec1332c9c2428c92f977192acc \
     --hash=sha256:988468260ec1c196dab6ae1149260e2f5472c9110334e5d51adcb77867361f6a
-black==21.6b0 \
-    --hash=sha256:dfb8c5a069012b2ab1e972e7b908f5fb42b6bbabcba0a788b86dc05067c7d9c7 \
-    --hash=sha256:dc132348a88d103016726fe360cb9ede02cecf99b76e3660ce6c596be132ce04
-bracex==2.1.1 \
+black==21.7b0; python_full_version >= "3.6.2" \
+    --hash=sha256:1c7aa6ada8ee864db745b22790a32f94b2795c253a75d6d9b5e439ff10d23116 \
+    --hash=sha256:c8373c6491de9362e39271630b65b964607bc5c79c83783547d76c839b3aa219
+bracex==2.1.1; python_version >= "3.6" \
     --hash=sha256:64e2a6d14de9c8e022cf40539ac8468ba7c4b99550a2b05fc87fd20e392e568f \
     --hash=sha256:01f715cd0ed7a622ec8b32322e715813f7574de531f09b70f6f3b2c10f682425
-cfgv==3.3.0 \
+cfgv==3.3.0; python_full_version >= "3.6.1" \
     --hash=sha256:b449c9c6118fe8cca7fa5e00b9ec60ba08145d281d52164230a69211c5d597a1 \
     --hash=sha256:9e600479b3b99e8af981ecdfc80a0296104ee610cab48a5ae4ffd0b668650eb1
-click==8.0.1 \
+click==8.0.1; python_version >= "3.6" and python_full_version >= "3.6.2" \
     --hash=sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6 \
     --hash=sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a
-colorama==0.4.4; platform_system == "Windows" \
+colorama==0.4.4; sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.6.2" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") and platform_system == "Windows" \
     --hash=sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2 \
     --hash=sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b
-coverage==5.5 \
+coverage==5.5; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4" \
     --hash=sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf \
     --hash=sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b \
     --hash=sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669 \
@@ -78,36 +78,36 @@ coverage==5.5 \
     --hash=sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079 \
     --hash=sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4 \
     --hash=sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c
-distlib==0.3.2 \
+distlib==0.3.2; python_full_version >= "3.6.1" \
     --hash=sha256:23e223426b28491b1ced97dc3bbe183027419dfc7982b4fa2f05d5f3ff10711c \
     --hash=sha256:106fef6dc37dd8c0e2c0a60d3fca3e77460a48907f335fa28420463a6f799736
-django==2.2.24 \
+django==2.2.24; python_version >= "3.5" \
     --hash=sha256:f2084ceecff86b1e631c2cd4107d435daf4e12f1efcdf11061a73bf0b5e95f92 \
     --hash=sha256:3339ff0e03dee13045aef6ae7b523edff75b6d726adf7a7a48f53d5a501f7db7
-djangorestframework==3.12.4 \
+djangorestframework==3.12.4; python_version >= "3.5" \
     --hash=sha256:6d1d59f623a5ad0509fe0d6bfe93cbdfe17b8116ebc8eda86d45f6e16e819aaf \
     --hash=sha256:f747949a8ddac876e879190df194b925c177cdeb725a099db1460872f7c0a7f2
-dnspython==2.1.0 \
+dnspython==2.1.0; python_full_version >= "3.6.1" and python_version >= "3.6" \
     --hash=sha256:95d12f6ef0317118d2a1a6fc49aac65ffec7eb8087474158f42f26a639135216 \
     --hash=sha256:e4a87f0b573201a0f3727fa18a516b055fd1107e0e5477cded4a2de497df1dd4
-email-validator==1.1.3 \
+email-validator==1.1.3; python_full_version >= "3.6.1" \
     --hash=sha256:5675c8ceb7106a37e40e2698a57c056756bf3f272cfa8682a4f87ebd95d8440b \
     --hash=sha256:aa237a65f6f4da067119b7df3f13e89c25c051327b2b5b66dc075f33d62480d7
 fastjsonschema==2.15.1 \
     --hash=sha256:fa2f4bb1e31419c5eb1150f2e0545921712c10c34165b86d33f08f5562ad4b85 \
     --hash=sha256:671f36d225b3493629b5e789428660109528f373cf4b8a22bac6fa2f8191c2d2
-filelock==3.0.12 \
+filelock==3.0.12; python_full_version >= "3.6.1" \
     --hash=sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836 \
     --hash=sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59
-flake8==3.9.2 \
+flake8==3.9.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0") \
     --hash=sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907 \
     --hash=sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b
-future-typing==0.4.1 \
+future-typing==0.4.1; python_version >= "3.6" \
     --hash=sha256:af19e06b7fe6fdfb8d83c265a2688cba9ac74b0a6a2dac14c268910ecd14ac8d \
     --hash=sha256:65fdc5034a95db212790fee5e977fb0a2df8deb60dccf3bac17d6d2b1a9bbacd
-ghp-import==2.0.1 \
+ghp-import==2.0.1; python_version >= "3.6" \
     --hash=sha256:753de2eace6e0f7d4edfb3cce5e3c3b98cd52aadb80163303d1d036bda7b4483
-greenlet==1.1.0; python_version >= "3" \
+greenlet==1.1.0; python_version >= "3" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3" \
     --hash=sha256:60848099b76467ef09b62b0f4512e7e6f0a2c977357a036de602b653667f5f4c \
     --hash=sha256:f42ad188466d946f1b3afc0a9e1a266ac8926461ee0786c06baac6bd71f8a6f3 \
     --hash=sha256:76ed710b4e953fc31c663b079d317c18f40235ba2e3d55f70ff80794f7b57922 \
@@ -157,31 +157,28 @@ greenlet==1.1.0; python_version >= "3" \
     --hash=sha256:adb94a28225005890d4cf73648b5131e885c7b4b17bc762779f061844aabcc11 \
     --hash=sha256:aa4230234d02e6f32f189fd40b59d5a968fe77e80f59c9c933384fe8ba535535 \
     --hash=sha256:c87df8ae3f01ffb4483c796fe1b15232ce2b219f0b18126948616224d3f658ee
-identify==2.2.11 \
+identify==2.2.11; python_full_version >= "3.6.1" \
     --hash=sha256:7abaecbb414e385752e8ce02d8c494f4fbc780c975074b46172598a28f1ab839 \
     --hash=sha256:a0e700637abcbd1caae58e0463861250095dfe330a8371733a471af706a4a29a
-idna==3.2 \
+idna==3.2; python_full_version >= "3.6.1" and python_version >= "3.5" \
     --hash=sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a \
     --hash=sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3
-importlib-metadata==4.6.1 \
+importlib-metadata==4.6.1; python_version < "3.8" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.6.0" and python_version < "3.8" and python_version >= "3.6") and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.5.0" and python_version < "3.8" and python_version >= "3.6") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") and python_full_version >= "3.6.2" and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.4.0" and python_version >= "3.6" and python_version < "3.8") \
     --hash=sha256:9f55f560e116f8643ecf2922d9cd3e1c7e8d52e683178fecd9d08f6aa357e11e \
     --hash=sha256:079ada16b7fc30dfbb5d13399a5113110dab1aa7c2bc62f66af75f0b717c8cac
-importlib-metadata==4.6.1; python_version < "3.8" \
-    --hash=sha256:9f55f560e116f8643ecf2922d9cd3e1c7e8d52e683178fecd9d08f6aa357e11e \
-    --hash=sha256:079ada16b7fc30dfbb5d13399a5113110dab1aa7c2bc62f66af75f0b717c8cac
-inflection==0.5.1 \
+inflection==0.5.1; python_version >= "3.5" \
     --hash=sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2 \
     --hash=sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417
-iniconfig==1.1.1 \
+iniconfig==1.1.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
-jinja2==3.0.1 \
+jinja2==3.0.1; python_version >= "3.6" \
     --hash=sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4 \
     --hash=sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4
-markdown==3.3.4 \
+markdown==3.3.4; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
     --hash=sha256:96c3ba1261de2f7547b46a00ea8463832c921d3f9d6aba3f255a6f71386db20c \
     --hash=sha256:31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49
-markupsafe==2.0.1 \
+markupsafe==2.0.1; python_version >= "3.6" \
     --hash=sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51 \
     --hash=sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff \
     --hash=sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b \
@@ -216,31 +213,31 @@ markupsafe==2.0.1 \
     --hash=sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74 \
     --hash=sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8 \
     --hash=sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a
-marshmallow==3.12.2 \
-    --hash=sha256:d4090ca9a36cd129126ad8b10c3982c47d4644a6e3ccb20534b512badce95f35 \
-    --hash=sha256:77368dfedad93c3a041cbbdbce0b33fac1d8608c9e2e2288408a43ce3493d2ff
-mccabe==0.6.1 \
+marshmallow==3.13.0; python_version >= "3.5" \
+    --hash=sha256:dd4724335d3c2b870b641ffe4a2f8728a1380cd2e7e2312756715ffeaa82b842 \
+    --hash=sha256:c67929438fd73a2be92128caa0325b1b5ed8b626d91a094d2f7f2771bf1f1c0e
+mccabe==0.6.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
-mergedeep==1.3.4 \
+mergedeep==1.3.4; python_version >= "3.6" \
     --hash=sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307 \
     --hash=sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8
-mkdocs-awesome-pages-plugin==2.5.0 \
+mkdocs-awesome-pages-plugin==2.5.0; python_version >= "3.5" \
     --hash=sha256:df51e908d64a7f736b4d772e19ce8ddb30c7337e06ac3dd7a29c51c431c5606e \
     --hash=sha256:a215eab780757734a84e33dfa3f7d1141e43576d47aadc1b8f869a7463162c69
-mkdocs-material-extensions==1.0.1 \
+mkdocs-material-extensions==1.0.1; python_version >= "3.5" \
     --hash=sha256:6947fb7f5e4291e3c61405bad3539d81e0b3cd62ae0d66ced018128af509c68f \
     --hash=sha256:d90c807a88348aa6d1805657ec5c0b2d8d609c110e62b9dce4daf7fa981fa338
 mkdocs-material==5.5.14 \
     --hash=sha256:9f3237df1a72f91e0330a5e3b3711cb7aaa0d5705f9585e6ce6fbacaa16e777f \
     --hash=sha256:a0b3b3e67606e04d13e777d13f3195402ea09e0c3ce279abc3666cac2c5b3a6d
-mkdocs==1.2.1 \
-    --hash=sha256:11141126e5896dd9d279b3e4814eb488e409a0990fb638856255020406a8e2e7 \
-    --hash=sha256:6e0ea175366e3a50d334597b0bc042b8cebd512398cdd3f6f34842d0ef524905
-mypy-extensions==0.4.3 \
+mkdocs==1.2.2; python_version >= "3.6" \
+    --hash=sha256:d019ff8e17ec746afeb54eb9eb4112b5e959597aebc971da46a5c9486137f0ff \
+    --hash=sha256:a334f5bd98ec960638511366eb8c5abc9c99b9083a0ed2401d8791b112d6b078
+mypy-extensions==0.4.3; python_version >= "3.5" and python_full_version >= "3.6.2" \
     --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
     --hash=sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8
-mypy==0.910 \
+mypy==0.910; python_version >= "3.5" \
     --hash=sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457 \
     --hash=sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb \
     --hash=sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9 \
@@ -264,70 +261,65 @@ mypy==0.910 \
     --hash=sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8 \
     --hash=sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d \
     --hash=sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150
-nodeenv==1.6.0 \
+nodeenv==1.6.0; python_full_version >= "3.6.1" \
     --hash=sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7 \
     --hash=sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b
-numpy==1.21.0 \
-    --hash=sha256:d5caa946a9f55511e76446e170bdad1d12d6b54e17a2afe7b189112ed4412bb8 \
-    --hash=sha256:ac4fd578322842dbda8d968e3962e9f22e862b6ec6e3378e7415625915e2da4d \
-    --hash=sha256:598fe100b2948465cf3ed64b1a326424b5e4be2670552066e17dfaa67246011d \
-    --hash=sha256:7c55407f739f0bfcec67d0df49103f9333edc870061358ac8a8c9e37ea02fcd2 \
-    --hash=sha256:75579acbadbf74e3afd1153da6177f846212ea2a0cc77de53523ae02c9256513 \
-    --hash=sha256:cc367c86eb87e5b7c9592935620f22d13b090c609f1b27e49600cd033b529f54 \
-    --hash=sha256:d89b0dc7f005090e32bb4f9bf796e1dcca6b52243caf1803fdd2b748d8561f63 \
-    --hash=sha256:eda2829af498946c59d8585a9fd74da3f810866e05f8df03a86f70079c7531dd \
-    --hash=sha256:1a784e8ff7ea2a32e393cc53eb0003eca1597c7ca628227e34ce34eb11645a0e \
-    --hash=sha256:bba474a87496d96e61461f7306fba2ebba127bed7836212c360f144d1e72ac54 \
-    --hash=sha256:fd0a359c1c17f00cb37de2969984a74320970e0ceef4808c32e00773b06649d9 \
-    --hash=sha256:e4d5a86a5257843a18fb1220c5f1c199532bc5d24e849ed4b0289fb59fbd4d8f \
-    --hash=sha256:620732f42259eb2c4642761bd324462a01cdd13dd111740ce3d344992dd8492f \
-    --hash=sha256:b9205711e5440954f861ceeea8f1b415d7dd15214add2e878b4d1cf2bcb1a914 \
-    --hash=sha256:ad09f55cc95ed8d80d8ab2052f78cc21cb231764de73e229140d81ff49d8145e \
-    --hash=sha256:a1f2fb2da242568af0271455b89aee0f71e4e032086ee2b4c5098945d0e11cf6 \
-    --hash=sha256:e58ddb53a7b4959932f5582ac455ff90dcb05fac3f8dcc8079498d43afbbde6c \
-    --hash=sha256:d2910d0a075caed95de1a605df00ee03b599de5419d0b95d55342e9a33ad1fb3 \
-    --hash=sha256:a290989cd671cd0605e9c91a70e6df660f73ae87484218e8285c6522d29f6e38 \
-    --hash=sha256:3537b967b350ad17633b35c2f4b1a1bbd258c018910b518c30b48c8e41272717 \
-    --hash=sha256:ccc6c650f8700ce1e3a77668bb7c43e45c20ac06ae00d22bdf6760b38958c883 \
-    --hash=sha256:709884863def34d72b183d074d8ba5cfe042bc3ff8898f1ffad0209161caaa99 \
-    --hash=sha256:bebab3eaf0641bba26039fb0b2c5bf9b99407924b53b1ea86e03c32c64ef5aef \
-    --hash=sha256:cf680682ad0a3bef56dae200dbcbac2d57294a73e5b0f9864955e7dd7c2c2491 \
-    --hash=sha256:d95d16204cd51ff1a1c8d5f9958ce90ae190be81d348b514f9be39f878b8044a \
-    --hash=sha256:2ba579dde0563f47021dcd652253103d6fd66165b18011dce1a0609215b2791e \
-    --hash=sha256:3c40e6b860220ed862e8097b8f81c9af6d7405b723f4a7af24a267b46f90e461 \
-    --hash=sha256:e80fe25cba41c124d04c662f33f6364909b985f2eb5998aaa5ae4b9587242cce
-packaging==21.0 \
+numpy==1.21.1; python_version >= "3.7.1" and python_version <= "3.9" and python_full_version >= "3.7.1" \
+    --hash=sha256:38e8648f9449a549a7dfe8d8755a5979b45b3538520d1e735637ef28e8c2dc50 \
+    --hash=sha256:fd7d7409fa643a91d0a05c7554dd68aa9c9bb16e186f6ccfe40d6e003156e33a \
+    --hash=sha256:a75b4498b1e93d8b700282dc8e655b8bd559c0904b3910b144646dbbbc03e062 \
+    --hash=sha256:1412aa0aec3e00bc23fbb8664d76552b4efde98fb71f60737c83efbac24112f1 \
+    --hash=sha256:e46ceaff65609b5399163de5893d8f2a82d3c77d5e56d976c8b5fb01faa6b671 \
+    --hash=sha256:c6a2324085dd52f96498419ba95b5777e40b6bcbc20088fddb9e8cbb58885e8e \
+    --hash=sha256:73101b2a1fef16602696d133db402a7e7586654682244344b8329cdcbbb82172 \
+    --hash=sha256:7a708a79c9a9d26904d1cca8d383bf869edf6f8e7650d85dbc77b041e8c5a0f8 \
+    --hash=sha256:95b995d0c413f5d0428b3f880e8fe1660ff9396dcd1f9eedbc311f37b5652e16 \
+    --hash=sha256:635e6bd31c9fb3d475c8f44a089569070d10a9ef18ed13738b03049280281267 \
+    --hash=sha256:4a3d5fb89bfe21be2ef47c0614b9c9c707b7362386c9a3ff1feae63e0267ccb6 \
+    --hash=sha256:8a326af80e86d0e9ce92bcc1e65c8ff88297de4fa14ee936cb2293d414c9ec63 \
+    --hash=sha256:791492091744b0fe390a6ce85cc1bf5149968ac7d5f0477288f78c89b385d9af \
+    --hash=sha256:0318c465786c1f63ac05d7c4dbcecd4d2d7e13f0959b01b534ea1e92202235c5 \
+    --hash=sha256:9a513bd9c1551894ee3d31369f9b07460ef223694098cf27d399513415855b68 \
+    --hash=sha256:91c6f5fc58df1e0a3cc0c3a717bb3308ff850abdaa6d2d802573ee2b11f674a8 \
+    --hash=sha256:978010b68e17150db8765355d1ccdd450f9fc916824e8c4e35ee620590e234cd \
+    --hash=sha256:9749a40a5b22333467f02fe11edc98f022133ee1bfa8ab99bda5e5437b831214 \
+    --hash=sha256:d7a4aeac3b94af92a9373d6e77b37691b86411f9745190d2c351f410ab3a791f \
+    --hash=sha256:d9e7912a56108aba9b31df688a4c4f5cb0d9d3787386b87d504762b6754fbb1b \
+    --hash=sha256:25b40b98ebdd272bc3020935427a4530b7d60dfbe1ab9381a39147834e985eac \
+    --hash=sha256:8a92c5aea763d14ba9d6475803fc7904bda7decc2a0a68153f587ad82941fec1 \
+    --hash=sha256:05a0f648eb28bae4bcb204e6fd14603de2908de982e761a2fc78efe0f19e96e1 \
+    --hash=sha256:f01f28075a92eede918b965e86e8f0ba7b7797a95aa8d35e1cc8821f5fc3ad6a \
+    --hash=sha256:88c0b89ad1cc24a5efbb99ff9ab5db0f9a86e9cc50240177a571fbe9c2860ac2 \
+    --hash=sha256:01721eefe70544d548425a07c80be8377096a54118070b8a62476866d5208e33 \
+    --hash=sha256:2d4d1de6e6fb3d28781c73fbde702ac97f03d79e4ffd6598b880b2d95d62ead4 \
+    --hash=sha256:dff4af63638afcc57a3dfb9e4b26d434a7a602d225b42d746ea7fe2edf1342fd
+packaging==21.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
     --hash=sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14 \
     --hash=sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7
-pandas==1.1.5 \
-    --hash=sha256:bf23a3b54d128b50f4f9d4675b3c1857a688cc6731a32f931837d72effb2698d \
-    --hash=sha256:5a780260afc88268a9d3ac3511d8f494fdcf637eece62fb9eb656a63d53eb7ca \
-    --hash=sha256:b61080750d19a0122469ab59b087380721d6b72a4e7d962e4d7e63e0c4504814 \
-    --hash=sha256:0de3ddb414d30798cbf56e642d82cac30a80223ad6fe484d66c0ce01a84d6f2f \
-    --hash=sha256:70865f96bb38fec46f7ebd66d4b5cfd0aa6b842073f298d621385ae3898d28b5 \
-    --hash=sha256:19a2148a1d02791352e9fa637899a78e371a3516ac6da5c4edc718f60cbae648 \
-    --hash=sha256:26fa92d3ac743a149a31b21d6f4337b0594b6302ea5575b37af9ca9611e8981a \
-    --hash=sha256:c16d59c15d946111d2716856dd5479221c9e4f2f5c7bc2d617f39d870031e086 \
-    --hash=sha256:3be7a7a0ca71a2640e81d9276f526bca63505850add10206d0da2e8a0a325dae \
-    --hash=sha256:573fba5b05bf2c69271a32e52399c8de599e4a15ab7cec47d3b9c904125ab788 \
-    --hash=sha256:21b5a2b033380adbdd36b3116faaf9a4663e375325831dac1b519a44f9e439bb \
-    --hash=sha256:24c7f8d4aee71bfa6401faeba367dd654f696a77151a8a28bc2013f7ced4af98 \
-    --hash=sha256:2860a97cbb25444ffc0088b457da0a79dc79f9c601238a3e0644312fcc14bf11 \
-    --hash=sha256:5008374ebb990dad9ed48b0f5d0038124c73748f5384cc8c46904dace27082d9 \
-    --hash=sha256:2c2f7c670ea4e60318e4b7e474d56447cf0c7d83b3c2a5405a0dbb2600b9c48e \
-    --hash=sha256:0a643bae4283a37732ddfcecab3f62dd082996021b980f580903f4e8e01b3c5b \
-    --hash=sha256:5447ea7af4005b0daf695a316a423b96374c9c73ffbd4533209c5ddc369e644b \
-    --hash=sha256:4c62e94d5d49db116bef1bd5c2486723a292d79409fc9abd51adf9e05329101d \
-    --hash=sha256:731568be71fba1e13cae212c362f3d2ca8932e83cb1b85e3f1b4dd77d019254a \
-    --hash=sha256:c61c043aafb69329d0f961b19faa30b1dab709dd34c9388143fc55680059e55a \
-    --hash=sha256:2b1c6cd28a0dfda75c7b5957363333f01d370936e4c6276b7b8e696dd500582a \
-    --hash=sha256:c94ff2780a1fd89f190390130d6d36173ca59fcfb3fe0ff596f9a56518191ccb \
-    --hash=sha256:edda9bacc3843dfbeebaf7a701763e68e741b08fccb889c003b0a52f0ee95782 \
-    --hash=sha256:f10fc41ee3c75a474d3bdf68d396f10782d013d7f67db99c0efbfd0acb99701b
-pathspec==0.8.1 \
-    --hash=sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d \
-    --hash=sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd
-pendulum==2.1.2 \
+pandas==1.3.0; python_version >= "3.7.1" and python_version <= "3.9" \
+    --hash=sha256:c81b8d91e9ae861eb4406b4e0f8d4dabbc105b9c479b3d1e921fba1d35b5b62a \
+    --hash=sha256:08eeff3da6a188e24db7f292b39a8ca9e073bf841fbbeadb946b3ad5c19d843e \
+    --hash=sha256:88864c1e28353b958b1f30e4193818519624ad9a1776921622a6a2a016d5d807 \
+    --hash=sha256:872aa91e0f9ca913046ab639d4181a899f5e592030d954d28c2529b88756a736 \
+    --hash=sha256:92835113a67cbd34747c198d41f09f4b63f6fe11ca5643baebc7ab1e30e89e95 \
+    --hash=sha256:7d3cd2c99faa94d717ca00ea489264a291ad7209453dffbf059bfb7971fd3a61 \
+    --hash=sha256:823737830364d0e2af8c3912a28ba971296181a07950873492ed94e12d28c405 \
+    --hash=sha256:c746876cdd8380be0c3e70966d4566855901ac9aaa5e4b9ccaa5ca5311457d11 \
+    --hash=sha256:fe7a549d10ca534797095586883a5c17d140d606747591258869c56e14d1b457 \
+    --hash=sha256:f058c786e7b0a9e7fa5e0b9f4422e0ccdd3bf3aa3053c18d77ed2a459bd9a45a \
+    --hash=sha256:98efc2d4983d5bb47662fe2d97b2c81b91566cb08b266490918b9c7d74a5ef64 \
+    --hash=sha256:e6b75091fa54a53db3927b4d1bc997c23c5ba6f87acdfe1ee5a92c38c6b2ed6a \
+    --hash=sha256:1ff13eed501e07e7fb26a4ea18a846b6e5d7de549b497025601fd9ccb7c1d123 \
+    --hash=sha256:798675317d0e4863a92a9a6bc5bd2490b5f6fef8c17b95f29e2e33f28bef9eca \
+    --hash=sha256:ed4fc66f23fe17c93a5d439230ca2d6b5f8eac7154198d327dbe8a16d98f3f10 \
+    --hash=sha256:522bfea92f3ef6207cadc7428bda1e7605dae0383b8065030e7b5d0266717b48 \
+    --hash=sha256:7897326cae660eee69d501cbfa950281a193fcf407393965e1bc07448e1cc35a \
+    --hash=sha256:b10d7910ae9d7920a5ff7816d794d99acbc361f7b16a0f017d4fa83ced8cb55e \
+    --hash=sha256:c554e6c9cf2d5ea1aba5979cc837b3649539ced0e18ece186f055450c86622e2
+pathspec==0.9.0; python_full_version >= "3.6.2" \
+    --hash=sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a \
+    --hash=sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1
+pendulum==2.1.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0") \
     --hash=sha256:b6c352f4bd32dff1ea7066bd31ad0f71f8d8100b9ff709fb343f3b86cee43efe \
     --hash=sha256:318f72f62e8e23cd6660dbafe1e346950281a9aed144b5c596b2ddabc1d19739 \
     --hash=sha256:0731f0c661a3cb779d398803655494893c9f581f6488048b3fb629c2342b5394 \
@@ -349,24 +341,24 @@ pendulum==2.1.2 \
     --hash=sha256:29c40a6f2942376185728c9a0347d7c0f07905638c83007e1d262781f1e6953a \
     --hash=sha256:94b1fc947bfe38579b28e1cccb36f7e28a15e841f30384b5ad6c5e31055c85d7 \
     --hash=sha256:b06a0ca1bfe41c990bbf0c029f0b6501a7f2ec4e38bfec730712015e8860f207
-platformdirs==2.0.2 \
+platformdirs==2.0.2; python_full_version >= "3.6.1" \
     --hash=sha256:0b9547541f599d3d242078ae60b927b3e453f0ad52f58b4d4bc3be86aed3ec41 \
     --hash=sha256:3b00d081227d9037bbbca521a5787796b5ef5000faea1e43fd76f1d44b06fcfa
-pluggy==0.13.1 \
+pluggy==0.13.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
     --hash=sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d \
     --hash=sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0
-pre-commit==2.13.0 \
+pre-commit==2.13.0; python_full_version >= "3.6.1" \
     --hash=sha256:b679d0fddd5b9d6d98783ae5f10fd0c4c59954f375b70a58cbe1ce9bcf9809a4 \
     --hash=sha256:764972c60693dc668ba8e86eb29654ec3144501310f7198742a767bec385a378
-py-cpuinfo==8.0.0 \
+py-cpuinfo==8.0.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" \
     --hash=sha256:5f269be0e08e33fd959de96b34cd4aeeeacac014dd8305f70eb28d06de2345c5
-py==1.10.0 \
+py==1.10.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
     --hash=sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a \
     --hash=sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3
-pycodestyle==2.7.0 \
+pycodestyle==2.7.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" \
     --hash=sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068 \
     --hash=sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef
-pydantic==1.8.2 \
+pydantic==1.8.2; python_full_version >= "3.6.1" \
     --hash=sha256:05ddfd37c1720c392f4e0d43c484217b7521558302e7069ce8d318438d297739 \
     --hash=sha256:a7c6002203fe2c5a1b5cbb141bb85060cbff88c2d78eccbc72d97eb7022c43e4 \
     --hash=sha256:589eb6cd6361e8ac341db97602eb7f354551482368a37f4fd086c0733548308e \
@@ -389,46 +381,46 @@ pydantic==1.8.2 \
     --hash=sha256:4be75bebf676a5f0f87937c6ddb061fa39cbea067240d98e298508c1bda6f3f3 \
     --hash=sha256:fec866a0b59f372b7e776f2d7308511784dace622e0992a0b59ea3ccee0ae833 \
     --hash=sha256:26464e57ccaafe72b7ad156fdaa4e9b9ef051f69e175dbbb463283000c05ab7b
-pyflakes==2.3.1 \
+pyflakes==2.3.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" \
     --hash=sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3 \
     --hash=sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db
-pygal==2.4.0 \
+pygal==2.4.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" \
     --hash=sha256:27abab93cbc31e21f3c6bdecc05bda6cd3570cbdbd8297b7caa6904051b50d72 \
     --hash=sha256:9204f05380b02a8a32f9bf99d310b51aa2a932cba5b369f7a4dc3705f0a4ce83
-pygaljs==1.0.2 \
+pygaljs==1.0.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" \
     --hash=sha256:d75e18cb21cc2cda40c45c3ee690771e5e3d4652bf57206f20137cf475c0dbe8 \
     --hash=sha256:0b71ee32495dcba5fbb4a0476ddbba07658ad65f5675e4ad409baf154dec5111
-pygments==2.9.0 \
+pygments==2.9.0; python_version >= "3.5" \
     --hash=sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e \
     --hash=sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f
-pymdown-extensions==7.1 \
+pymdown-extensions==7.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0") \
     --hash=sha256:5bf93d1ccd8281948cd7c559eb363e59b179b5373478e8a7195cf4b78e3c11b6 \
     --hash=sha256:8f415b21ee86d80bb2c3676f4478b274d0a8ccb13af672a4c86b9ffd22bd005c
-pyparsing==2.4.7 \
+pyparsing==2.4.7; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6" \
     --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1
-pytest-benchmark==3.4.1 \
+pytest-benchmark==3.4.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0") \
     --hash=sha256:40e263f912de5a81d891619032983557d62a3d85843f9a9f30b98baea0cd7b47 \
     --hash=sha256:36d2b08c4882f6f997fd3126a3d6dfd70f3249cde178ed8bbc0b73db7c20f809
-pytest-cov==2.12.1 \
+pytest-cov==2.12.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0") \
     --hash=sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7 \
     --hash=sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a
-pytest==6.2.4 \
+pytest==6.2.4; python_version >= "3.6" \
     --hash=sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890 \
     --hash=sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b
-python-dateutil==2.8.1 \
-    --hash=sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c \
-    --hash=sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a
-pytz==2021.1 \
+python-dateutil==2.8.2; python_version >= "3.7.1" and python_version <= "3.9" and python_full_version >= "3.7.1" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") \
+    --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
+    --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
+pytz==2021.1; python_version >= "3.7.1" and python_version <= "3.9" and python_full_version >= "3.7.1" \
     --hash=sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798 \
     --hash=sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da
-pytzdata==2020.1 \
+pytzdata==2020.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" \
     --hash=sha256:e1e14750bcf95016381e4d472bad004eef710f2d6417240904070b3d6654485f \
     --hash=sha256:3efa13b335a00a8de1d345ae41ec78dd11c9f8807f522d39850f2dd828681540
-pyyaml-env-tag==0.1 \
+pyyaml-env-tag==0.1; python_version >= "3.6" \
     --hash=sha256:af31106dec8a4d68c60207c1886031cbf839b68aa7abccdb19868200532c2069 \
     --hash=sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb
-pyyaml==5.4.1 \
+pyyaml==5.4.1; python_full_version >= "3.6.1" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6") \
     --hash=sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922 \
     --hash=sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393 \
     --hash=sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8 \
@@ -458,7 +450,7 @@ pyyaml==5.4.1 \
     --hash=sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10 \
     --hash=sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db \
     --hash=sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e
-regex==2021.7.6 \
+regex==2021.7.6; python_full_version >= "3.6.2" \
     --hash=sha256:e6a1e5ca97d411a461041d057348e578dc344ecd2add3555aedba3b408c9f874 \
     --hash=sha256:6afe6a627888c9a6cfbb603d1d017ce204cebd589d66e0703309b8048c3b0854 \
     --hash=sha256:ccb3d2190476d00414aab36cca453e4596e8f70a206e2aa8db3d495a109153d2 \
@@ -500,52 +492,55 @@ regex==2021.7.6 \
     --hash=sha256:eaf58b9e30e0e546cdc3ac06cf9165a1ca5b3de8221e9df679416ca667972035 \
     --hash=sha256:4c9c3155fe74269f61e27617529b7f09552fbb12e44b1189cebbdb24294e6e1c \
     --hash=sha256:8394e266005f2d8c6f0bc6780001f7afa3ef81a7a2111fa35058ded6fce79e4d
-six==1.16.0 \
+six==1.16.0; python_full_version >= "3.6.1" \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926
 sqlalchemy-stubs==0.3 \
     --hash=sha256:a3318c810697164e8c818aa2d90bac570c1a0e752ced3ec25455b309c0bee8fd \
     --hash=sha256:ca1250605a39648cc433f5c70cb1a6f9fe0b60bdda4c51e1f9a2ab3651daadc8
-sqlalchemy==1.4.20 \
-    --hash=sha256:525dd3c2205b11a2bc6d770bf1ec63bde0253fd754b4c19c399d27ddc9dad0d3 \
-    --hash=sha256:4a67371752fd86d1d03a3b82d4e75404608f6f4d579b9676124079a22a40c79f \
-    --hash=sha256:7150e5b543b466f45f668b352f7abda27998cc8035f051d1b7e9524ca9eb2f5f \
-    --hash=sha256:6da83225a23eaf7b3f48f3d5f53c91b2cf00fbfa48b24a7a758160112dd3e123 \
-    --hash=sha256:9841762d114018c49483c089fa2d47f7e612e57666323f615913d7d7f46e9606 \
-    --hash=sha256:eaee5dd378f6f0d7c3ec49aeeb26564d55ac0ad73b9b4688bf29e66deabddf73 \
-    --hash=sha256:9eb25bcf9161e2fcbe9eebe8e829719b2334e849183f0e496bf4b83722bcccfa \
-    --hash=sha256:8d860c62e3f51623ccd528d8fac44580501df557d4b467cc5581587fcf057719 \
-    --hash=sha256:0f6d467b67a7e5048f1408e8ea60d6caa70be5b386d0eebbf1185ab49cb8c7e4 \
-    --hash=sha256:ff8bebc7a9d297dff2003460e01db2c20c63818b45fb19170f388b1a72fe5a14 \
-    --hash=sha256:46361690f1e1c5385994a4caeb6e8126063ff593a5c635700bbc1245de793c1e \
-    --hash=sha256:c0eb2cd3ad4967fcbdd9e066e8cd91fe2c23c671dbae9952f0b4d3d42832cc5f \
-    --hash=sha256:76fbc24311a3d039d6cd147d396719f606d96d1413f3816c028a48e29367f646 \
-    --hash=sha256:f14acb0fd16d404fda9370f93aace682f284340c89c3442ac747c5466ac7e2b5 \
-    --hash=sha256:fcd84e4d46a86291495d131a7824ba38d2e8278bda9425c50661a04633174319 \
-    --hash=sha256:2f60a2e599cf5cf5e5327ce60f2918b897e42ad9f405d10dd01e37869c0ce6fc \
-    --hash=sha256:f6fc526bd70898489d02bf52c8f0632ab377592ae954d0c0a5bb38d618dddaa9 \
-    --hash=sha256:25c0e0f3a7e8c19350086b3c0fe93c4def045cec053d749ef15da710c4d54c81 \
-    --hash=sha256:e0d48456e1aa4f0537f9c9af7be71e1f0659ff68bc1cd538ebc785f6b007bd0d \
-    --hash=sha256:9675d5bc7e4f96a7bb2b54d14e9b269a5fb6e5d36ecc7d01f0f65bb9af3185f9 \
-    --hash=sha256:b502b5e2f08500cc4b8d29bfc4f51d805adcbc00f8d149e98fda8aae85ddb644 \
-    --hash=sha256:aad3234a41340e9cf6184e621694e2a7233ba3f8aef9b1e6de8cba431b45ebd2 \
-    --hash=sha256:6c8406c3d8c1c7d15da454de15d77f7bb48d14ede5db994f74226c348cf1050e \
-    --hash=sha256:238d78b3110b7f7cffdb70bf9cda686e0d876a849bc78ba4d471aa7b1461f306 \
-    --hash=sha256:854a7b15750e617e16f8d65dbc004f065a7963544b253b923f16109557648777 \
-    --hash=sha256:ff38ecf89c69a531a7326c2dae71982edfe2f805f3c016cdc5bfd1a04ebf80cb \
-    --hash=sha256:86c079732328f1add097b0b8079cd532b5d28e207fac93e9d6ea5f487506deef \
-    --hash=sha256:46b99eab618cdc1c871ea707b7c52edc23cfea6c750740cd242ba62b5c84de7f \
-    --hash=sha256:b86d83fefc8a8c394f3490c37e1953bc16c311a3d1d1cf91518793bfb9847fb4 \
-    --hash=sha256:38ee3a266afef2978e82824650457f70c5d74ec0cadec1b10fe5ed6f038eb5d0
-sqlparse==0.4.1 \
+sqlalchemy==1.4.22; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0") \
+    --hash=sha256:488608953385d6c127d2dcbc4b11f8d7f2f30b89f6bd27c01b042253d985cc2f \
+    --hash=sha256:5d856cc50fd26fc8dd04892ed5a5a3d7eeb914fea2c2e484183e2d84c14926e0 \
+    --hash=sha256:a00d9c6d3a8afe1d1681cd8a5266d2f0ed684b0b44bada2ca82403b9e8b25d39 \
+    --hash=sha256:5908ea6c652a050d768580d01219c98c071e71910ab8e7b42c02af4010608397 \
+    --hash=sha256:b7fb937c720847879c7402fe300cfdb2aeff22349fa4ea3651bca4e2d6555939 \
+    --hash=sha256:9bfe882d5a1bbde0245dca0bd48da0976bd6634cf2041d2fdf0417c5463e40e5 \
+    --hash=sha256:eedd76f135461cf237534a6dc0d1e0f6bb88a1dc193678fab48a11d223462da5 \
+    --hash=sha256:6a16c7c4452293da5143afa3056680db2d187b380b3ef4d470d4e29885720de3 \
+    --hash=sha256:44d23ea797a5e0be71bc5454b9ae99158ea0edc79e2393c6e9a2354de88329c0 \
+    --hash=sha256:a5e14cb0c0a4ac095395f24575a0e7ab5d1be27f5f9347f1762f21505e3ba9f1 \
+    --hash=sha256:bc34a007e604091ca3a4a057525efc4cefd2b7fe970f44d20b9cfa109ab1bddb \
+    --hash=sha256:756f5d2f5b92d27450167247fb574b09c4cd192a3f8c2e493b3e518a204ee543 \
+    --hash=sha256:9fcbb4b4756b250ed19adc5e28c005b8ed56fdb5c21efa24c6822c0575b4964d \
+    --hash=sha256:09dbb4bc01a734ccddbf188deb2a69aede4b3c153a72b6d5c6900be7fb2945b1 \
+    --hash=sha256:f028ef6a1d828bc754852a022b2160e036202ac8658a6c7d34875aafd14a9a15 \
+    --hash=sha256:68393d3fd31469845b6ba11f5b4209edbea0b58506be0e077aafbf9aa2e21e11 \
+    --hash=sha256:891927a49b2363a4199763a9d436d97b0b42c65922a4ea09025600b81a00d17e \
+    --hash=sha256:fd2102a8f8a659522719ed73865dff3d3cc76eb0833039dc473e0ad3041d04be \
+    --hash=sha256:4014978de28163cd8027434916a92d0f5bb1a3a38dff5e8bf8bff4d9372a9117 \
+    --hash=sha256:f814d80844969b0d22ea63663da4de5ca1c434cfbae226188901e5d368792c17 \
+    --hash=sha256:d09a760b0a045b4d799102ae7965b5491ccf102123f14b2a8cc6c01d1021a2d9 \
+    --hash=sha256:26daa429f039e29b1e523bf763bfab17490556b974c77b5ca7acb545b9230e9a \
+    --hash=sha256:12bac5fa1a6ea870bdccb96fe01610641dd44ebe001ed91ef7fcd980e9702db5 \
+    --hash=sha256:39b5d36ab71f73c068cdcf70c38075511de73616e6c7fdd112d6268c2704d9f5 \
+    --hash=sha256:5102b9face693e8b2db3b2539c7e1a5d9a5b4dc0d79967670626ffd2f710d6e6 \
+    --hash=sha256:c9373ef67a127799027091fa53449125351a8c943ddaa97bec4e99271dbb21f4 \
+    --hash=sha256:36a089dc604032d41343d86290ce85d4e6886012eea73faa88001260abf5ff81 \
+    --hash=sha256:b48148ceedfb55f764562e04c00539bb9ea72bf07820ca15a594a9a049ff6b0e \
+    --hash=sha256:1fdae7d980a2fa617d119d0dc13ecb5c23cc63a8b04ffcb5298f2c59d86851e9 \
+    --hash=sha256:ec1be26cdccd60d180359a527d5980d959a26269a2c7b1b327a1eea0cab37ed8
+sqlparse==0.4.1; python_version >= "3.5" \
     --hash=sha256:017cde379adbd6a1f15a61873f43e8274179378e95ef3fede90b5aa64d304ed0 \
     --hash=sha256:0f91fd2e829c44362cbcfab3e9ae12e22badaa8a29ad5ff599f9ec109f0454e8
 toastedmarshmallow==2.15.2.post1 \
     --hash=sha256:aad7c89720a27d6362e1362394ceaedf5e1648aba4506c1971da35b3642810e9
-toml==0.10.2 \
+toml==0.10.2; python_full_version >= "3.6.1" and python_version >= "3.6" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
-typed-ast==1.4.3; python_version < "3.8" \
+tomli==1.1.0; python_version >= "3.6" and python_full_version >= "3.6.2" \
+    --hash=sha256:f4a182048010e89cbec0ae4686b21f550a7f2903f665e34a6de58ec15424f919 \
+    --hash=sha256:33d7984738f8bb699c9b0a816eb646a8178a69eaa792d258486776a5d21b8ca5
+typed-ast==1.4.3; python_version < "3.8" and python_version >= "3.5" and python_full_version >= "3.6.2" \
     --hash=sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6 \
     --hash=sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075 \
     --hash=sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528 \
@@ -576,272 +571,11 @@ typed-ast==1.4.3; python_version < "3.8" \
     --hash=sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808 \
     --hash=sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c \
     --hash=sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65
-types-aiofiles==0.1.7 \
-    --hash=sha256:e5364aed6bcc784e62cbed396b712290cbac349b3f7d41fde6f0681eff9b38d2 \
-    --hash=sha256:227c0bab8cd956b9f2002127d5e97628a555b0939628cc960127c26d9fde7805
-types-all==1.0.0 \
-    --hash=sha256:5de4a3c9f9c5687978fd05c3bc08e6b70b0c4c093a50e3ef866bbe50c5534a68 \
-    --hash=sha256:b61d204c31b733e4296e666399c0ecf829844ab7080d77e5404fa55ef1d7d972
-types-annoy==1.17.2 \
-    --hash=sha256:cfbdfe9228a8ef6e301e90cde0b8592758302cf5edeb7966bcb3a49cde7da245 \
-    --hash=sha256:7a937320b240b19dd5ed41387fd31c3e89190d42029e3be85fd090eaa77c81c1
-types-atomicwrites==0.1.5 \
-    --hash=sha256:778d6ab2d188ac41d08f62a1f671b003af57ae1feba208b59433272d5ac1202a \
-    --hash=sha256:9b73ac447ce007329575d3684d756fc636c89d8652b3bbd9e289953de15c88e7
-types-backports-abc==0.1.4 \
-    --hash=sha256:4b94b6761171ebc68dc894738792ba602de7a100230396d0f751a44104981479 \
-    --hash=sha256:101f230f0f7995b4d781fb27623a3543d138b899dc1667d3ca33636255edcb4a
-types-backports==0.1.3 \
-    --hash=sha256:f4b7206c073df88d6200891e3d27506185fd60cda66fb289737b2fa92c0010cf \
-    --hash=sha256:dafcd61848081503e738a7768872d1dd6c018401b4d2a1cfb608ea87ec9864b9
-types-bleach==3.3.3 \
-    --hash=sha256:431db47fb76a2e47d2fe076136dc591ab7c73db47511519718f0bd5db83eb3b4 \
-    --hash=sha256:73f684ffb17d21db3f062363b144c3506c951c1107e0f562c2476413013436a9
-types-boto==0.1.2 \
-    --hash=sha256:deb707cb39212f2f5d3c53341ceb40f6d3b312b549e706603a101c4949f3399c \
-    --hash=sha256:ced3bc0b00fd39f55fc721b14cab2ac9a1b632501c647b98fef837d59be0b430
-types-cachetools==0.1.9 \
-    --hash=sha256:cfcb41a71d5dab7b785fa3adeb367fa7584062c4d74e6d91ac72538a349b5f7b \
-    --hash=sha256:c3fa1afdfdeaf3cdc396ad5518ef3e6984f73092be61b525708f23f527aea51d
-types-certifi==0.1.4 \
-    --hash=sha256:7c134d978f15e4aa2d2b1a85b2a92241ed6b256c3452511b7783b6a28b304b71 \
-    --hash=sha256:afe4d94726491d843f10e5746797689ea5dcbd78454a653be47d72a8c8ce3bed
-types-characteristic==0.1.3 \
-    --hash=sha256:2cd9aca1c0d24bae96b42a4539166d91ba2c530cf4a8698d6766268e2960fbf2 \
-    --hash=sha256:6142cdaea930eab6853f0a02c4facb70b292e10612698b58dba0cbe2c8642a11
-types-chardet==0.1.3 \
-    --hash=sha256:f9e6dfa655a2a7228e8128ef0f70a8b77f1176514ec2c055ca414ee883af1246 \
-    --hash=sha256:6927c7ed3d477f51fbea5c708d79f9b13183b2fc229ca837ca1cdc1f4c43d699
-types-click-spinner==0.1.4 \
-    --hash=sha256:f1620fc24623031adb5a56cdc1a4094a69d6138f7a964930a6ea87dc4d6f21a1 \
-    --hash=sha256:7838c2a38bfaa36ec7c91f31a80fcf218469c06597f9dcbbaeed5091482d2de4
-types-click==7.1.2 \
-    --hash=sha256:040897284e4f9466825c3865f708a985a8e7ba4d8e22cb9198ffb7b522160850 \
-    --hash=sha256:4722746f1ec9fd3fc8b1d7fb8c840604dc22f9e32bcc7a31a36d6d85cc2bce24
-types-colorama==0.4.2 \
-    --hash=sha256:ae4f7fcb533e529c182b934423b0c589452ec8b3470430b2ee7baf06cb7f4a8d \
-    --hash=sha256:42bd280fad509c698e1485f9658493076d315d189a5014be843dffee2d264902
-types-contextvars==0.1.4 \
-    --hash=sha256:427fa5e9f00859de653a1f5dfe91c6f2283325f4a2893fca56ff1c473b3d7cf5 \
-    --hash=sha256:d3327970cdcf3b7d8b89e693c091ab0bc0b804246a100f7a5d8a86d5622780a0
-types-croniter==0.1.4 \
-    --hash=sha256:7eb0eba21b45114e901a2a685ba8a162d7014d3e06365083a7b39c193c1ef45c \
-    --hash=sha256:c0ec4205a6e2d1723d3d9c163e649e976accb4218a082855c68fcee875bbb720
-types-cryptography==3.3.3 \
-    --hash=sha256:de2b12e971023b25bd96b7da251dc747ea5b4670a998f9160153d96e4f918f0b \
-    --hash=sha256:524afedb2e7f3fa4b22bd164efb82809a75ff960cc5d40a2fa9b7c2cda228fab
-types-dataclasses==0.1.5 \
-    --hash=sha256:7b5f4099fb21c209f2df3a83c2b64308c29955769d610a457244dc0eebe1cafc \
-    --hash=sha256:c19491cfb981bff9cafd9c113c291a7a54adccc6298ded8ca3de0d7abe211984
-types-dateparser==0.1.3 \
-    --hash=sha256:bbb0c199bbfc0f8f811eb0c5e6bf80ff68dd15bf30f3e7ee68411f6106e3209b \
-    --hash=sha256:f96df44c5fa6d71a9c0a5523fb8f1109b5844c19d5a9beb7b20868a68a20ede0
-types-datetimerange==0.1.2 \
-    --hash=sha256:d0154a5ed968b97ff66ca16e295c9eadd39bf67fc490cd9eb714ecda09496da7 \
-    --hash=sha256:0da96620b7d16eae61e41d9501ec6b4888589464ff5d7fa92d7132108a21ded0
-types-decorator==0.1.5 \
-    --hash=sha256:88c8f0f4229124f7bea7cbd968dea48aebbfb0144f0b50c0ec810fe18916cf65 \
-    --hash=sha256:76045ca8ccb4cf2a2ccbaa36d02a75f4ec07af334036771af0a0b0ea0503d4a9
-types-deprecated==0.1.3 \
-    --hash=sha256:b1d32e0faa954af93cf8fb2a4309c3a7d09b0e7f4a77957f41156b1724d19dc2 \
-    --hash=sha256:e2b0f2b28a07e3d4dd8d04b9f153056906ab9313b7da9f6716bb2c1c485d4624
-types-docopt==0.6.2 \
-    --hash=sha256:647874c49fd8c9cecf8977b5102f3968cae5c0df64f11127d0745cdc64a9e51c \
-    --hash=sha256:34b9b66dbddffc596f4cf70ddd40c1248c2b65c81ca460eaf902f5a147f68fb1
-types-docutils==0.1.7 \
-    --hash=sha256:241b901395b4da05de39fe4aa364acc55536029e51308e11673f51e74e861645 \
-    --hash=sha256:61f1e12f3b090c28979338830f122d5bfc1a2287156a8c384b6142ce6d0aa8ec
-types-emoji==1.2.2 \
-    --hash=sha256:6d8f26809f41dbbbd3c7604415eba29a06edbc665784fd63fe2fd706729aacec \
-    --hash=sha256:e10ca236f4e5da74e1f7881ca8c768de8d18f714c8118755328263f321168bd8
-types-enum34==0.1.8 \
-    --hash=sha256:9e91a94f1f42c73bd7aa43f19a157d722522d29097f301748a034e08693a423d \
-    --hash=sha256:5833cfd003d7a860e8442d04a06aaa2bef1f050933f844fa7bd3634914e1aa7f
-types-fb303==0.1.6 \
-    --hash=sha256:2dc85a814e3c85da5d4d345efbc6ab0d804c6a1d4beb1a219c2a7381e2842286 \
-    --hash=sha256:cfb004c174756d078b5f2a53154290f9529b8e73f3c54ec23e8426013bc5532f
-types-filelock==0.1.4 \
-    --hash=sha256:f73f0e9637cb5a39aec57542d359df826e7b910cb87e1f7902275c91fb5466b6 \
-    --hash=sha256:ce002b38659eb64f0338c02a025078f52c550e5da4ca5c10a70c1adf4b8d19fa
-types-first==0.1.5 \
-    --hash=sha256:82f7553489fcc16a031132f9be8401b4d0be11fd3f35a4f61edb6c1153f93ddf \
-    --hash=sha256:6e7465c0c09951d07e00d845474edf2ad0b4a27f4e7ea34394c8d77243e35e88
-types-flask==1.1.1 \
-    --hash=sha256:90afe8bd050cf8830cdc620bb9aa4471836b86af88e4d33fccc8789242a661e2 \
-    --hash=sha256:4885fd9c64756b0901d3de0a197d0ede60df114d0fbab500aa1bd73bb2c1651c
-types-freezegun==0.1.4 \
-    --hash=sha256:4b4a391598af0c5695d56f6af7ac36faf2a757e3f50046a2e95b3a01ba889fcd \
-    --hash=sha256:e90a30b16daf3ca0758c2bce53f47ea7d2e8520f14c28a3dc6108bcb67bb7525
-types-frozendict==0.1.5 \
-    --hash=sha256:fa5e6a24adfe23db1e37c5f571bca5dda4c0ab388ec03462e498ed22c2449494 \
-    --hash=sha256:9e08c9593d6a20b13411fcf4e7597dbae896d06afaf664c7759dee5cb180d969
-types-futures==0.1.6 \
-    --hash=sha256:da372dd55dc08c257de1e3dfd56273e44af9668e077047b0509adcfc43dd2838 \
-    --hash=sha256:7cb32c3fb4885089d78873a28ad33db3d5300661eac8b3ad327f4f5616fdf742
-types-geoip2==0.1.2 \
-    --hash=sha256:2a62031c9bb0916f05ad7ed8d3dd4d51243658385177256a5460625786bf3885 \
-    --hash=sha256:90be79d7ec742d14310266bb4c32f154ac14c488b0e60338b78aa3871d7cc886
-types-ipaddress==0.1.5 \
-    --hash=sha256:ffa2c4fe2e8f51898465e2142d4d325fbab009aaa7822db20a4e2e3a896560d7 \
-    --hash=sha256:137ab8a5a895a48157438c8f3eea738e2c22e82c1114ab20ffd78c8637bbc008
-types-itsdangerous==1.1.2 \
-    --hash=sha256:f9817850bc7f0caecf4301fa17395ee3685e6afd3a4aea73156df3508e1177bb \
-    --hash=sha256:52b44e2a80bb456c70961c5fb24b5299b2e1239d8740dc8b611c20f0ea7af6e4
-types-jack-client==0.1.5 \
-    --hash=sha256:0a9524b20d361f2adec9a646f4c9e217c89acb3795463b24b1394acb46f9962c \
-    --hash=sha256:c09c246a04c853f217db37b2843812c5646669bc80d8e4fdaf50344a58267670
-types-jinja2==2.11.2 \
-    --hash=sha256:5b53d2b8bc6dd6dfbc0ae3e33e346fbe343cbeba1ed528858749e2a2ffe0e143 \
-    --hash=sha256:d27e112a8add449407de235f4533239149056327c8bddc6b0d6bf80cd7280c16
-types-kazoo==0.1.3 \
-    --hash=sha256:97a3b95e2437fcc093506e822b009c1ee9e4db6906631b5320117f0d2be4aa4a \
-    --hash=sha256:885cb481b2af327f6ecae725c9e2770ece454c675b94ea5e367dbc76243e7418
-types-markdown==3.3.0 \
-    --hash=sha256:b7bf9ce52a9f712c6a59b75350ed435d6fc1f1d5eafed44a321472bf96cf77db \
-    --hash=sha256:cc18cc0fcc2ba8ab3f5233b2945db33e2e68ddad179708b2d2f08da08d33bc4e
-types-markupsafe==1.1.4 \
-    --hash=sha256:4fd2cc858fb4aea38555850f4ac2ecafae3543c88abb056669a3346c5c1b202c \
-    --hash=sha256:2539a9e9b1b5a1bf1c10fdf2cb1dcb89e6f360759196883f4d5d103c53624375
-types-maxminddb==0.1.2 \
-    --hash=sha256:debf4605e18390d3a38e8c92d383288fbb529c48fb594acffe6a8253c8df5d1a \
-    --hash=sha256:16e616a188efcebfdd6208321a6c7d747e976e7b8a316c67f19992139d46104c
-types-mock==0.1.3 \
-    --hash=sha256:9bdafab236c0530fed36dbf18bc942633b2033bfda16551b2e4eb767341a8b8c \
-    --hash=sha256:e052879bb0a7d78547cce3342ffdf4ec3e8d2eff8f237911c3c8e31ac7ea8c86
-types-mypy-extensions==0.4.5 \
-    --hash=sha256:b34f184f09fd789e7673e2f8bbe4bf37b18cd4eb455fbec2f5d1c536d5b059a4 \
-    --hash=sha256:479798a2c169394cff9d5407d03844c3478b73d01de81810128e1109223965a4
-types-nmap==0.1.4 \
-    --hash=sha256:82e146fe34106fb1bff7108e854be1ebc9cc715e676db4f152844677c485968b \
-    --hash=sha256:5d726b114dc9b8226f9791c5dfb81e93c28b9b5aff0e6b6b366568263c0ed394
-types-openssl-python==0.1.3 \
-    --hash=sha256:8f58ebae880550412f8aad619a7615e49471de2766dfc35aa7faa5609d01ffe5
-types-orjson==0.1.1 \
-    --hash=sha256:7454bfbaed27900a844bb9d8e211b69f1c335f0b9e3541d4950a793db41c104d \
-    --hash=sha256:92f85986261ea1a5cb215e4b35e4016631d35163a372f023918750f340ea737f
-types-paramiko==0.1.7 \
-    --hash=sha256:51ce59aea222c47d0590e2b8d8cefbc5aeb469d8bf6368e4f06ad3c61c932c72 \
-    --hash=sha256:9fb9f3a363c99ae735148a7ce3c28adbe8f87797ec3c8cce3103899acbdebfa8
-types-pathlib2==2.2.0 \
-    --hash=sha256:36a574ac953208372df7f94c6f2bf1ba8c9b79e31023fe5440f96c57351a19b5 \
-    --hash=sha256:198b2f6795067661d32f00c1bc1b6689ec2d664a029462fd3c208433b1fb2898
-types-pillow==8.3.1 \
-    --hash=sha256:12329f4700941f60a0054194815b4bf674e5dfac73debd97ef7548c51f2c5103 \
-    --hash=sha256:9556ba9cb25f570371bd082dc30fe77a549a22bac035ce9d3a606bfc541d12ec
-types-pkg-resources==0.1.3 \
-    --hash=sha256:834a9b8d3dbea343562fd99d5d3359a726f6bf9d3733bccd2b4f3096fbab9dae \
-    --hash=sha256:0cb9972cee992249f93fff1a491bf2dc3ce674e5a1926e27d4f0866f7d9b6d9c
-types-polib==1.1.1 \
-    --hash=sha256:1689820c1644080506ce30441c82eba931cae4f1133973030398cdc3164a4832 \
-    --hash=sha256:319c60b02236228c7ef4f1c937b0b39e7364812195dacf1cb02d802a9a54f5c4
-types-protobuf==3.17.0 \
-    --hash=sha256:00f6c405c67f0144b92e0baab6610c4d4356c2927ee86f77aa71ac2a8648cb8a \
-    --hash=sha256:dd7df3487c1dc9011653472d3bc7dd486c6b73151707fda12cdef30a0501fd1e
-types-pyaudio==0.2.2 \
-    --hash=sha256:90650b96f513f1c31dac1870e56a8db67e9b0ecd23db876f3ea0ae96f684abe0 \
-    --hash=sha256:0ea6852eeab934802795e8f5ce112192b0b95ea88fc8988870fba032c68043c8
-types-pycurl==0.1.3 \
-    --hash=sha256:a125d5c7dc5dd98dcf3611fca315b451ad89c8fedf800f4c035193123eb30f85 \
-    --hash=sha256:fab2aa57cee019e484eabba4b16d35934b72ac87366ff8e9006867b95ea51f4c
-types-pyfarmhash==0.2.1 \
-    --hash=sha256:c9fe7f5bf5002d7453e72b03bd8ce0dd3d8bd70223d783abce547758cd72cb6b \
-    --hash=sha256:4038decaac51c36c2c8cb9b5e11b149b825a1c1897098563e7a49be034f0658c
-types-pyjwt==1.7.1 \
-    --hash=sha256:99c1a0d94d370951f9c6e57b1c369be280b2cbfab72c0f9c0998707490f015c9 \
-    --hash=sha256:810112a84b6c060bb5bc1959a1d229830465eccffa91d8a68eeaac28fb7713ac
-types-pymssql==0.1.4 \
-    --hash=sha256:26c52c01d867bfbda1e1ddb3aec25b5372a702d6f0e82e604f014635e7d9920c \
-    --hash=sha256:260b45d3af54f7e4020cc55e0c198974479d1e53e55d48142af06e827c313538
-types-pymysql==1.0.0 \
-    --hash=sha256:528f1602a54fc0ba9bc6ebe6b6f756c33e9a8ed4dfbf1cad05f4b9781f43886d \
-    --hash=sha256:32e0e966140954803ed03a9b740fae08dfee8a9a299f2b2b7951bb6754eade19
-types-pyrfc3339==0.1.1 \
-    --hash=sha256:80569ea7c6a97f4b5f46e4db26b8a7c0beac3a117f5e74b33a6190275c999e4d \
-    --hash=sha256:9632e221a33f96304dc654c7a43ea986995d9b0acf8fad6714baa40962ee4089
-types-pysftp==0.2.2 \
-    --hash=sha256:ea0a2a3eafb112f95481676d33c75c308c712ad24080ea439114017f4f9528ea \
-    --hash=sha256:88148e80a46070f4358f1a37fb06b57851f26f21b3ceae32b030456db8e85db7
-types-python-dateutil==0.1.4 \
-    --hash=sha256:e6486ca27b6dde73e0ec079a9e1b03e208766e6bc7f1e08964a7e9104a5c7d7a \
-    --hash=sha256:39bfe0bde61fc673b8fa28167bd78622d976210f791971b9f3e10877cbf119a4
-types-python-gflags==0.1.2 \
-    --hash=sha256:e408179c5e2edd69a85d1fffb2f052ae17dc837ab939f8462cdef36f689a5b44 \
-    --hash=sha256:e8eb02892afac83e9827f501da14805bcae92c1dfb7c568f914b1c8f3b4f9bb8
-types-python-slugify==0.1.1 \
-    --hash=sha256:98dd5a5fcc1d37d2d05698ca744c808e2fb1cac8aa1b1a43e0430d2dd25392c5 \
-    --hash=sha256:16f0c1dc95c385bc9770feb357e322e7f53440fe87e7ea941fb54bbe7a84d4df
-types-pytz==2021.1.0 \
-    --hash=sha256:addfa2a1a27b324b6beb422faa4737962532bbab3793481d5bdebbffb8f9f243 \
-    --hash=sha256:ec9555397f91518b2cf028ed837a69e388763c6a5e58abffaf37732f9c581a46
-types-pyvmomi==0.1.2 \
-    --hash=sha256:505513fa265d43d64ca2a1bad7d3f08f162a46141c9f8b48d3eb4d69fc6d78e1 \
-    --hash=sha256:6f2079ba312ae2cdc9489a656f1df0d40dfd7598a380d257aaa5a827bfbff35a
-types-pyyaml==5.4.3 \
-    --hash=sha256:2e7b81b2b7af751634425107b986086c6ba7cb61270a43a5c290c58be8cdbc3a \
-    --hash=sha256:bca83cbfc0be48600a8abf1e3d87fb762a91e6d35d724029a3321dd2dce2ceb1
-types-redis==3.5.4 \
-    --hash=sha256:936e98f9090c11610f4f5171d2ca8fa5c5eab842422b3cc2f9355f57d01e1a6b \
-    --hash=sha256:954feb1f573216b215c1d564c1b27091a7ce8b7fd3af9474d9e88d4081881aff
-types-requests==2.25.0 \
-    --hash=sha256:ee0d0c507210141b7d5b8639cc43eaa726084178775db2a5fb06fbf85c185808 \
-    --hash=sha256:fa5c1e5e832ff6193507d8da7e1159281383908ee193a2f4b37bc08140b51844
-types-retry==0.1.3 \
-    --hash=sha256:a81397633b3a5c621c01975919e43a11301fb854f6af66088f783b8cd4473f53 \
-    --hash=sha256:9ff6a3570f7fbe42c6580c8a422c191453bfa16a46e346003b5990e0bc03da40
-types-routes==0.1.7 \
-    --hash=sha256:2c762baac6e31b544966bd0171b60edaffad3fd8b8670fbb0048860c1f885859 \
-    --hash=sha256:d844ff7cb438b862fe7f803d9158f24d41e1a4af410a5759be9b33d8093617db
-types-scribe==0.1.3 \
-    --hash=sha256:573ae400cfd46d9b4bf4574bf7035c7969cc25c396ed0789b42e0db6e1b92e66 \
-    --hash=sha256:ce255505e4920b666babd91754ae07efb52d6f237235ba586a37e439fa817c98
-types-simplejson==0.1.4 \
-    --hash=sha256:851ae514c21b209a39d2679f865110199e37bbde5507684817c6e5ee81ca4bca \
-    --hash=sha256:1318ecb45d95983e5d31c2559853032174f1646ccad00056604e6f0c98e14e1e
-types-singledispatch==0.1.1 \
-    --hash=sha256:bf864ae28a67f59c8b4e25200ce330390cb943f069cb0cb49f3f6500f98ddb44 \
-    --hash=sha256:9e405cd019bc1a268d768a3bad56437fc95b12a2ee49cc1a981bba703aba6dd6
-types-six==0.1.7 \
-    --hash=sha256:254484e024fbef5aafd6eee80642d713e3c240e12103dbd0f41e1f602402ff35 \
-    --hash=sha256:ec2b7b1bcc521b3741f9317eca8fb3bfd0e39efe427231d57b37ad40af418a5e
-types-tabulate==0.1.1 \
-    --hash=sha256:d1a415a8601391bc8450a669402ad57a1b620acf8d8d206fcbb3accc1440b106 \
-    --hash=sha256:34a4900c32a56db8c7e5a1c8857332e8d02fe45077ea0ed53a3a12a10cbdbd0c
-types-termcolor==0.1.1 \
-    --hash=sha256:4d9e09ce7f3267985f5280b22e25790c98cb64628b6466e1fb915dbb52ad7136 \
-    --hash=sha256:3694c312e32f71fdc0f469c334ea21645f3130d90c93cd53bcb06b1233e174d5
-types-toml==0.1.3 \
-    --hash=sha256:33ebe67bebaec55a123ecbaa2bd98fe588335d8d8dda2c7ac53502ef5a81a79a \
-    --hash=sha256:d4add39a90993173d49ff0b069edd122c66ad4cf5c01082b590e380ca670ee1a
-types-tornado==5.1.0 \
-    --hash=sha256:67c7224563a70aee0a623bc38fdb676cc77b7877d73a4a50510fb89b4221c8ac \
-    --hash=sha256:5d8ef5d14aca5922ff028b635dcb04836f945b3356e5ec312eb773bc7a0fe920
-types-typed-ast==1.4.2 \
-    --hash=sha256:6a47165760321835d160da20a6ac5b9065f23d6dc246162508cad1ef1238afc3 \
-    --hash=sha256:014ab2742015d3eaab86ea061c27809c7e76beeb9e134102f2e2ddb34ab05c62
-types-tzlocal==0.1.1 \
-    --hash=sha256:2ebbe89d0f1f8deec1d5724f400ea9bf10e87f86f4937ccb20a62183dd6ca103 \
-    --hash=sha256:c2026603d3fe783eb63b0ab8d1fad13ff9df7ccc5da01bea8b4cb2bdbb8c6cef
-types-ujson==0.1.1 \
-    --hash=sha256:92042cb7a0ba0ded003642da3367aa2a7b22a7d16ce840336b50977781526ed0 \
-    --hash=sha256:f465118573d69c1cf570144de95c11a596abee4b48cf45c9c54abf0613d8956a
-types-waitress==0.1.7 \
-    --hash=sha256:ef19cfaf80e4a330dd3c552847ad7525ad6ea51707c11b2c5fa9594e9b31880e \
-    --hash=sha256:3f498d2a5a199c91fa21b1fef86aefe9144ad2831bcb226b7e82ee660c04e4d1
-types-werkzeug==1.0.2 \
-    --hash=sha256:7f6d4c8771a67d44e83134d56e59b482bf81ebd28e6557015fdfcc81e3d11b53 \
-    --hash=sha256:1a4e551955e6fc608cf6b93a2749963b9cce5ff56cddfc90404af1c919afa937
-types-xxhash==0.1.4 \
-    --hash=sha256:7b8148981f01c6b517e635420d3a3ae58f9d33b72a446e5d97b511a4413da6af \
-    --hash=sha256:ac3805e8f1de7401a8632e63500f8929a19096cd4a5945e0e5ec320a81c45d7c
-typing-extensions==3.10.0.0 \
+typing-extensions==3.10.0.0; python_full_version >= "3.6.2" and python_version >= "3.6" and python_version < "3.8" \
     --hash=sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497 \
     --hash=sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84 \
     --hash=sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342
-typing-extensions==3.10.0.0; python_version < "3.8" \
-    --hash=sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497 \
-    --hash=sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84 \
-    --hash=sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342
-ujson==3.2.0 \
+ujson==3.2.0; python_version >= "3.5" \
     --hash=sha256:437e051a3e292ddbd5b4682f9b6c3e2ea4cd059d0d75bc9f8314349d63cbb015 \
     --hash=sha256:a27ea44406100a97fb0fcc0b18dcdaf324824e722a00856a2992fafc65779351 \
     --hash=sha256:6f7c24dabb0ff0ff43744d18211af6035ef37197f530c13edf704e627da7251d \
@@ -863,10 +597,10 @@ ujson==3.2.0 \
     --hash=sha256:7b6496b3e2bc396628f114fd96ec41655b10c84adececc0ef8cf1c2329dae36c \
     --hash=sha256:782bdf016da793a3bf138e50ed973428e59006b8d73a9e1911bc6207c6b79fff \
     --hash=sha256:abb1996ba1c1d2faf5b1e38efa97da7f64e5373a31f705b96fe0587f5f778db4
-virtualenv==20.5.0 \
-    --hash=sha256:b7afa7f32abbf7dd4c24269a596cfbb0a422bb83c47215a785a7bf607cb88e1b \
-    --hash=sha256:6b0e3eeb6cb081c9c81ec85633785e29edcdf6ff271d70e0d1e2bd616495c08c
-watchdog==2.1.3 \
+virtualenv==20.6.0; python_full_version >= "3.6.1" \
+    --hash=sha256:e4fc84337dce37ba34ef520bf2d4392b392999dbe47df992870dc23230f6b758 \
+    --hash=sha256:51df5d8a2fad5d1b13e088ff38a433475768ff61f202356bb9812c454c20ae45
+watchdog==2.1.3; python_version >= "3.6" \
     --hash=sha256:9628f3f85375a17614a2ab5eac7665f7f7be8b6b0a2a228e6f6a2e91dd4bfe26 \
     --hash=sha256:acc4e2d5be6f140f02ee8590e51c002829e2c33ee199036fcd61311d558d89f4 \
     --hash=sha256:85b851237cf3533fabbc034ffcd84d0fa52014b3121454e5f8b86974b531560c \
@@ -888,9 +622,9 @@ watchdog==2.1.3 \
     --hash=sha256:44acad6f642996a2b50bb9ce4fb3730dde08f23e79e20cd3d8e2a2076b730381 \
     --hash=sha256:0bcdf7b99b56a3ae069866c33d247c9994ffde91b620eaf0306b27e099bd1ae0 \
     --hash=sha256:e5236a8e8602ab6db4b873664c2d356c365ab3cac96fbdec4970ad616415dd45
-wcmatch==8.2 \
+wcmatch==8.2; python_version >= "3.6" \
     --hash=sha256:9146b1ab9354e0797ef6ef69bc89cb32cb9f46d1b9eeef69c559aeec8f3bffb6 \
     --hash=sha256:4d54ddb506c90b5a5bba3a96a1cfb0bb07127909e19046a71d689ddfb18c3617
-zipp==3.5.0 \
+zipp==3.5.0; python_version < "3.8" and python_version >= "3.6" \
     --hash=sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3 \
     --hash=sha256:f5812b1e007e48cff63449a5e9f4e7ebea716b4111f9c4f9a645f91d579bf0c4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,630 +1,70 @@
-appdirs==1.4.4; python_full_version >= "3.6.2" \
-    --hash=sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128 \
-    --hash=sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41
-atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.4.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") \
-    --hash=sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197 \
-    --hash=sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a
-attrs==21.2.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
-    --hash=sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1 \
-    --hash=sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb
-backports.entry-points-selectable==1.1.0; python_version >= "2.7" and python_full_version >= "3.6.1" \
-    --hash=sha256:a6d9a871cde5e15b4c4a53e3d43ba890cc6861ec1332c9c2428c92f977192acc \
-    --hash=sha256:988468260ec1c196dab6ae1149260e2f5472c9110334e5d51adcb77867361f6a
-black==21.7b0; python_full_version >= "3.6.2" \
-    --hash=sha256:1c7aa6ada8ee864db745b22790a32f94b2795c253a75d6d9b5e439ff10d23116 \
-    --hash=sha256:c8373c6491de9362e39271630b65b964607bc5c79c83783547d76c839b3aa219
-bracex==2.1.1; python_version >= "3.6" \
-    --hash=sha256:64e2a6d14de9c8e022cf40539ac8468ba7c4b99550a2b05fc87fd20e392e568f \
-    --hash=sha256:01f715cd0ed7a622ec8b32322e715813f7574de531f09b70f6f3b2c10f682425
-cfgv==3.3.0; python_full_version >= "3.6.1" \
-    --hash=sha256:b449c9c6118fe8cca7fa5e00b9ec60ba08145d281d52164230a69211c5d597a1 \
-    --hash=sha256:9e600479b3b99e8af981ecdfc80a0296104ee610cab48a5ae4ffd0b668650eb1
-click==8.0.1; python_version >= "3.6" and python_full_version >= "3.6.2" \
-    --hash=sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6 \
-    --hash=sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a
-colorama==0.4.4; sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.6.2" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") and platform_system == "Windows" \
-    --hash=sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2 \
-    --hash=sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b
-coverage==5.5; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4" \
-    --hash=sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf \
-    --hash=sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b \
-    --hash=sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669 \
-    --hash=sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90 \
-    --hash=sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c \
-    --hash=sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a \
-    --hash=sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82 \
-    --hash=sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905 \
-    --hash=sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083 \
-    --hash=sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5 \
-    --hash=sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81 \
-    --hash=sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6 \
-    --hash=sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0 \
-    --hash=sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae \
-    --hash=sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb \
-    --hash=sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160 \
-    --hash=sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6 \
-    --hash=sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701 \
-    --hash=sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793 \
-    --hash=sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e \
-    --hash=sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3 \
-    --hash=sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066 \
-    --hash=sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a \
-    --hash=sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465 \
-    --hash=sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb \
-    --hash=sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821 \
-    --hash=sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45 \
-    --hash=sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184 \
-    --hash=sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a \
-    --hash=sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53 \
-    --hash=sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d \
-    --hash=sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638 \
-    --hash=sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3 \
-    --hash=sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a \
-    --hash=sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a \
-    --hash=sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6 \
-    --hash=sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2 \
-    --hash=sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759 \
-    --hash=sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873 \
-    --hash=sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a \
-    --hash=sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6 \
-    --hash=sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502 \
-    --hash=sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b \
-    --hash=sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529 \
-    --hash=sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b \
-    --hash=sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff \
-    --hash=sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b \
-    --hash=sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6 \
-    --hash=sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03 \
-    --hash=sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079 \
-    --hash=sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4 \
-    --hash=sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c
-distlib==0.3.2; python_full_version >= "3.6.1" \
-    --hash=sha256:23e223426b28491b1ced97dc3bbe183027419dfc7982b4fa2f05d5f3ff10711c \
-    --hash=sha256:106fef6dc37dd8c0e2c0a60d3fca3e77460a48907f335fa28420463a6f799736
-django==2.2.24; python_version >= "3.5" \
-    --hash=sha256:f2084ceecff86b1e631c2cd4107d435daf4e12f1efcdf11061a73bf0b5e95f92 \
-    --hash=sha256:3339ff0e03dee13045aef6ae7b523edff75b6d726adf7a7a48f53d5a501f7db7
-djangorestframework==3.12.4; python_version >= "3.5" \
-    --hash=sha256:6d1d59f623a5ad0509fe0d6bfe93cbdfe17b8116ebc8eda86d45f6e16e819aaf \
-    --hash=sha256:f747949a8ddac876e879190df194b925c177cdeb725a099db1460872f7c0a7f2
-dnspython==2.1.0; python_full_version >= "3.6.1" and python_version >= "3.6" \
-    --hash=sha256:95d12f6ef0317118d2a1a6fc49aac65ffec7eb8087474158f42f26a639135216 \
-    --hash=sha256:e4a87f0b573201a0f3727fa18a516b055fd1107e0e5477cded4a2de497df1dd4
-email-validator==1.1.3; python_full_version >= "3.6.1" \
-    --hash=sha256:5675c8ceb7106a37e40e2698a57c056756bf3f272cfa8682a4f87ebd95d8440b \
-    --hash=sha256:aa237a65f6f4da067119b7df3f13e89c25c051327b2b5b66dc075f33d62480d7
-fastjsonschema==2.15.1 \
-    --hash=sha256:fa2f4bb1e31419c5eb1150f2e0545921712c10c34165b86d33f08f5562ad4b85 \
-    --hash=sha256:671f36d225b3493629b5e789428660109528f373cf4b8a22bac6fa2f8191c2d2
-filelock==3.0.12; python_full_version >= "3.6.1" \
-    --hash=sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836 \
-    --hash=sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59
-flake8==3.9.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0") \
-    --hash=sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907 \
-    --hash=sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b
-future-typing==0.4.1; python_version >= "3.6" \
-    --hash=sha256:af19e06b7fe6fdfb8d83c265a2688cba9ac74b0a6a2dac14c268910ecd14ac8d \
-    --hash=sha256:65fdc5034a95db212790fee5e977fb0a2df8deb60dccf3bac17d6d2b1a9bbacd
-ghp-import==2.0.1; python_version >= "3.6" \
-    --hash=sha256:753de2eace6e0f7d4edfb3cce5e3c3b98cd52aadb80163303d1d036bda7b4483
-greenlet==1.1.0; python_version >= "3" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3" \
-    --hash=sha256:60848099b76467ef09b62b0f4512e7e6f0a2c977357a036de602b653667f5f4c \
-    --hash=sha256:f42ad188466d946f1b3afc0a9e1a266ac8926461ee0786c06baac6bd71f8a6f3 \
-    --hash=sha256:76ed710b4e953fc31c663b079d317c18f40235ba2e3d55f70ff80794f7b57922 \
-    --hash=sha256:b33b51ab057f8a20b497ffafdb1e79256db0c03ef4f5e3d52e7497200e11f821 \
-    --hash=sha256:ed1377feed808c9c1139bdb6a61bcbf030c236dd288d6fca71ac26906ab03ba6 \
-    --hash=sha256:da862b8f7de577bc421323714f63276acb2f759ab8c5e33335509f0b89e06b8f \
-    --hash=sha256:5f75e7f237428755d00e7460239a2482fa7e3970db56c8935bd60da3f0733e56 \
-    --hash=sha256:258f9612aba0d06785143ee1cbf2d7361801c95489c0bd10c69d163ec5254a16 \
-    --hash=sha256:5d928e2e3c3906e0a29b43dc26d9b3d6e36921eee276786c4e7ad9ff5665c78a \
-    --hash=sha256:cc407b68e0a874e7ece60f6639df46309376882152345508be94da608cc0b831 \
-    --hash=sha256:0c557c809eeee215b87e8a7cbfb2d783fb5598a78342c29ade561440abae7d22 \
-    --hash=sha256:3d13da093d44dee7535b91049e44dd2b5540c2a0e15df168404d3dd2626e0ec5 \
-    --hash=sha256:b3090631fecdf7e983d183d0fad7ea72cfb12fa9212461a9b708ff7907ffff47 \
-    --hash=sha256:06ecb43b04480e6bafc45cb1b4b67c785e183ce12c079473359e04a709333b08 \
-    --hash=sha256:944fbdd540712d5377a8795c840a97ff71e7f3221d3fddc98769a15a87b36131 \
-    --hash=sha256:c767458511a59f6f597bfb0032a1c82a52c29ae228c2c0a6865cfeaeaac4c5f5 \
-    --hash=sha256:2325123ff3a8ecc10ca76f062445efef13b6cf5a23389e2df3c02a4a527b89bc \
-    --hash=sha256:598bcfd841e0b1d88e32e6a5ea48348a2c726461b05ff057c1b8692be9443c6e \
-    --hash=sha256:be9768e56f92d1d7cd94185bab5856f3c5589a50d221c166cc2ad5eb134bd1dc \
-    --hash=sha256:dfe7eac0d253915116ed0cd160a15a88981a1d194c1ef151e862a5c7d2f853d3 \
-    --hash=sha256:9a6b035aa2c5fcf3dbbf0e3a8a5bc75286fc2d4e6f9cfa738788b433ec894919 \
-    --hash=sha256:ca1c4a569232c063615f9e70ff9a1e2fee8c66a6fb5caf0f5e8b21a396deec3e \
-    --hash=sha256:3096286a6072553b5dbd5efbefc22297e9d06a05ac14ba017233fedaed7584a8 \
-    --hash=sha256:c35872b2916ab5a240d52a94314c963476c989814ba9b519bc842e5b61b464bb \
-    --hash=sha256:b97c9a144bbeec7039cca44df117efcbeed7209543f5695201cacf05ba3b5857 \
-    --hash=sha256:16183fa53bc1a037c38d75fdc59d6208181fa28024a12a7f64bb0884434c91ea \
-    --hash=sha256:6b1d08f2e7f2048d77343279c4d4faa7aef168b3e36039cba1917fffb781a8ed \
-    --hash=sha256:14927b15c953f8f2d2a8dffa224aa78d7759ef95284d4c39e1745cf36e8cdd2c \
-    --hash=sha256:9bdcff4b9051fb1aa4bba4fceff6a5f770c6be436408efd99b76fc827f2a9319 \
-    --hash=sha256:c70c7dd733a4c56838d1f1781e769081a25fade879510c5b5f0df76956abfa05 \
-    --hash=sha256:0de64d419b1cb1bfd4ea544bedea4b535ef3ae1e150b0f2609da14bbf48a4a5f \
-    --hash=sha256:8833e27949ea32d27f7e96930fa29404dd4f2feb13cce483daf52e8842ec246a \
-    --hash=sha256:c1580087ab493c6b43e66f2bdd165d9e3c1e86ef83f6c2c44a29f2869d2c5bd5 \
-    --hash=sha256:ad80bb338cf9f8129c049837a42a43451fc7c8b57ad56f8e6d32e7697b115505 \
-    --hash=sha256:a9017ff5fc2522e45562882ff481128631bf35da444775bc2776ac5c61d8bcae \
-    --hash=sha256:7920e3eccd26b7f4c661b746002f5ec5f0928076bd738d38d894bb359ce51927 \
-    --hash=sha256:408071b64e52192869129a205e5b463abda36eff0cebb19d6e63369440e4dc99 \
-    --hash=sha256:be13a18cec649ebaab835dff269e914679ef329204704869f2f167b2c163a9da \
-    --hash=sha256:22002259e5b7828b05600a762579fa2f8b33373ad95a0ee57b4d6109d0e589ad \
-    --hash=sha256:206295d270f702bc27dbdbd7651e8ebe42d319139e0d90217b2074309a200da8 \
-    --hash=sha256:096cb0217d1505826ba3d723e8981096f2622cde1eb91af9ed89a17c10aa1f3e \
-    --hash=sha256:03f28a5ea20201e70ab70518d151116ce939b412961c33827519ce620957d44c \
-    --hash=sha256:7db68f15486d412b8e2cfcd584bf3b3a000911d25779d081cbbae76d71bd1a7e \
-    --hash=sha256:70bd1bb271e9429e2793902dfd194b653221904a07cbf207c3139e2672d17959 \
-    --hash=sha256:f92731609d6625e1cc26ff5757db4d32b6b810d2a3363b0ff94ff573e5901f6f \
-    --hash=sha256:06d7ac89e6094a0a8f8dc46aa61898e9e1aec79b0f8b47b2400dd51a44dbc832 \
-    --hash=sha256:adb94a28225005890d4cf73648b5131e885c7b4b17bc762779f061844aabcc11 \
-    --hash=sha256:aa4230234d02e6f32f189fd40b59d5a968fe77e80f59c9c933384fe8ba535535 \
-    --hash=sha256:c87df8ae3f01ffb4483c796fe1b15232ce2b219f0b18126948616224d3f658ee
-identify==2.2.11; python_full_version >= "3.6.1" \
-    --hash=sha256:7abaecbb414e385752e8ce02d8c494f4fbc780c975074b46172598a28f1ab839 \
-    --hash=sha256:a0e700637abcbd1caae58e0463861250095dfe330a8371733a471af706a4a29a
-idna==3.2; python_full_version >= "3.6.1" and python_version >= "3.5" \
-    --hash=sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a \
-    --hash=sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3
-importlib-metadata==4.6.1; python_version < "3.8" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.6.0" and python_version < "3.8" and python_version >= "3.6") and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.5.0" and python_version < "3.8" and python_version >= "3.6") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") and python_full_version >= "3.6.2" and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.4.0" and python_version >= "3.6" and python_version < "3.8") \
-    --hash=sha256:9f55f560e116f8643ecf2922d9cd3e1c7e8d52e683178fecd9d08f6aa357e11e \
-    --hash=sha256:079ada16b7fc30dfbb5d13399a5113110dab1aa7c2bc62f66af75f0b717c8cac
-inflection==0.5.1; python_version >= "3.5" \
-    --hash=sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2 \
-    --hash=sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417
-iniconfig==1.1.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
-    --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
-    --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
-jinja2==3.0.1; python_version >= "3.6" \
-    --hash=sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4 \
-    --hash=sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4
-markdown==3.3.4; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
-    --hash=sha256:96c3ba1261de2f7547b46a00ea8463832c921d3f9d6aba3f255a6f71386db20c \
-    --hash=sha256:31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49
-markupsafe==2.0.1; python_version >= "3.6" \
-    --hash=sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51 \
-    --hash=sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff \
-    --hash=sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b \
-    --hash=sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94 \
-    --hash=sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872 \
-    --hash=sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f \
-    --hash=sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d \
-    --hash=sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9 \
-    --hash=sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567 \
-    --hash=sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18 \
-    --hash=sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f \
-    --hash=sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f \
-    --hash=sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2 \
-    --hash=sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d \
-    --hash=sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415 \
-    --hash=sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914 \
-    --hash=sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066 \
-    --hash=sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35 \
-    --hash=sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b \
-    --hash=sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298 \
-    --hash=sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75 \
-    --hash=sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb \
-    --hash=sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64 \
-    --hash=sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833 \
-    --hash=sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26 \
-    --hash=sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7 \
-    --hash=sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8 \
-    --hash=sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5 \
-    --hash=sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135 \
-    --hash=sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902 \
-    --hash=sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509 \
-    --hash=sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74 \
-    --hash=sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8 \
-    --hash=sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a
-marshmallow==3.13.0; python_version >= "3.5" \
-    --hash=sha256:dd4724335d3c2b870b641ffe4a2f8728a1380cd2e7e2312756715ffeaa82b842 \
-    --hash=sha256:c67929438fd73a2be92128caa0325b1b5ed8b626d91a094d2f7f2771bf1f1c0e
-mccabe==0.6.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" \
-    --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
-    --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
-mergedeep==1.3.4; python_version >= "3.6" \
-    --hash=sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307 \
-    --hash=sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8
-mkdocs-awesome-pages-plugin==2.5.0; python_version >= "3.5" \
-    --hash=sha256:df51e908d64a7f736b4d772e19ce8ddb30c7337e06ac3dd7a29c51c431c5606e \
-    --hash=sha256:a215eab780757734a84e33dfa3f7d1141e43576d47aadc1b8f869a7463162c69
-mkdocs-material-extensions==1.0.1; python_version >= "3.5" \
-    --hash=sha256:6947fb7f5e4291e3c61405bad3539d81e0b3cd62ae0d66ced018128af509c68f \
-    --hash=sha256:d90c807a88348aa6d1805657ec5c0b2d8d609c110e62b9dce4daf7fa981fa338
-mkdocs-material==5.5.14 \
-    --hash=sha256:9f3237df1a72f91e0330a5e3b3711cb7aaa0d5705f9585e6ce6fbacaa16e777f \
-    --hash=sha256:a0b3b3e67606e04d13e777d13f3195402ea09e0c3ce279abc3666cac2c5b3a6d
-mkdocs==1.2.2; python_version >= "3.6" \
-    --hash=sha256:d019ff8e17ec746afeb54eb9eb4112b5e959597aebc971da46a5c9486137f0ff \
-    --hash=sha256:a334f5bd98ec960638511366eb8c5abc9c99b9083a0ed2401d8791b112d6b078
-mypy-extensions==0.4.3; python_version >= "3.5" and python_full_version >= "3.6.2" \
-    --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
-    --hash=sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8
-mypy==0.910; python_version >= "3.5" \
-    --hash=sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457 \
-    --hash=sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb \
-    --hash=sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9 \
-    --hash=sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e \
-    --hash=sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921 \
-    --hash=sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6 \
-    --hash=sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212 \
-    --hash=sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885 \
-    --hash=sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0 \
-    --hash=sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de \
-    --hash=sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703 \
-    --hash=sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a \
-    --hash=sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504 \
-    --hash=sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9 \
-    --hash=sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072 \
-    --hash=sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811 \
-    --hash=sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e \
-    --hash=sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b \
-    --hash=sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2 \
-    --hash=sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97 \
-    --hash=sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8 \
-    --hash=sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d \
-    --hash=sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150
-nodeenv==1.6.0; python_full_version >= "3.6.1" \
-    --hash=sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7 \
-    --hash=sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b
-numpy==1.21.1; python_version >= "3.7.1" and python_version <= "3.9" and python_full_version >= "3.7.1" \
-    --hash=sha256:38e8648f9449a549a7dfe8d8755a5979b45b3538520d1e735637ef28e8c2dc50 \
-    --hash=sha256:fd7d7409fa643a91d0a05c7554dd68aa9c9bb16e186f6ccfe40d6e003156e33a \
-    --hash=sha256:a75b4498b1e93d8b700282dc8e655b8bd559c0904b3910b144646dbbbc03e062 \
-    --hash=sha256:1412aa0aec3e00bc23fbb8664d76552b4efde98fb71f60737c83efbac24112f1 \
-    --hash=sha256:e46ceaff65609b5399163de5893d8f2a82d3c77d5e56d976c8b5fb01faa6b671 \
-    --hash=sha256:c6a2324085dd52f96498419ba95b5777e40b6bcbc20088fddb9e8cbb58885e8e \
-    --hash=sha256:73101b2a1fef16602696d133db402a7e7586654682244344b8329cdcbbb82172 \
-    --hash=sha256:7a708a79c9a9d26904d1cca8d383bf869edf6f8e7650d85dbc77b041e8c5a0f8 \
-    --hash=sha256:95b995d0c413f5d0428b3f880e8fe1660ff9396dcd1f9eedbc311f37b5652e16 \
-    --hash=sha256:635e6bd31c9fb3d475c8f44a089569070d10a9ef18ed13738b03049280281267 \
-    --hash=sha256:4a3d5fb89bfe21be2ef47c0614b9c9c707b7362386c9a3ff1feae63e0267ccb6 \
-    --hash=sha256:8a326af80e86d0e9ce92bcc1e65c8ff88297de4fa14ee936cb2293d414c9ec63 \
-    --hash=sha256:791492091744b0fe390a6ce85cc1bf5149968ac7d5f0477288f78c89b385d9af \
-    --hash=sha256:0318c465786c1f63ac05d7c4dbcecd4d2d7e13f0959b01b534ea1e92202235c5 \
-    --hash=sha256:9a513bd9c1551894ee3d31369f9b07460ef223694098cf27d399513415855b68 \
-    --hash=sha256:91c6f5fc58df1e0a3cc0c3a717bb3308ff850abdaa6d2d802573ee2b11f674a8 \
-    --hash=sha256:978010b68e17150db8765355d1ccdd450f9fc916824e8c4e35ee620590e234cd \
-    --hash=sha256:9749a40a5b22333467f02fe11edc98f022133ee1bfa8ab99bda5e5437b831214 \
-    --hash=sha256:d7a4aeac3b94af92a9373d6e77b37691b86411f9745190d2c351f410ab3a791f \
-    --hash=sha256:d9e7912a56108aba9b31df688a4c4f5cb0d9d3787386b87d504762b6754fbb1b \
-    --hash=sha256:25b40b98ebdd272bc3020935427a4530b7d60dfbe1ab9381a39147834e985eac \
-    --hash=sha256:8a92c5aea763d14ba9d6475803fc7904bda7decc2a0a68153f587ad82941fec1 \
-    --hash=sha256:05a0f648eb28bae4bcb204e6fd14603de2908de982e761a2fc78efe0f19e96e1 \
-    --hash=sha256:f01f28075a92eede918b965e86e8f0ba7b7797a95aa8d35e1cc8821f5fc3ad6a \
-    --hash=sha256:88c0b89ad1cc24a5efbb99ff9ab5db0f9a86e9cc50240177a571fbe9c2860ac2 \
-    --hash=sha256:01721eefe70544d548425a07c80be8377096a54118070b8a62476866d5208e33 \
-    --hash=sha256:2d4d1de6e6fb3d28781c73fbde702ac97f03d79e4ffd6598b880b2d95d62ead4 \
-    --hash=sha256:dff4af63638afcc57a3dfb9e4b26d434a7a602d225b42d746ea7fe2edf1342fd
-packaging==21.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
-    --hash=sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14 \
-    --hash=sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7
-pandas==1.3.0; python_version >= "3.7.1" and python_version <= "3.9" \
-    --hash=sha256:c81b8d91e9ae861eb4406b4e0f8d4dabbc105b9c479b3d1e921fba1d35b5b62a \
-    --hash=sha256:08eeff3da6a188e24db7f292b39a8ca9e073bf841fbbeadb946b3ad5c19d843e \
-    --hash=sha256:88864c1e28353b958b1f30e4193818519624ad9a1776921622a6a2a016d5d807 \
-    --hash=sha256:872aa91e0f9ca913046ab639d4181a899f5e592030d954d28c2529b88756a736 \
-    --hash=sha256:92835113a67cbd34747c198d41f09f4b63f6fe11ca5643baebc7ab1e30e89e95 \
-    --hash=sha256:7d3cd2c99faa94d717ca00ea489264a291ad7209453dffbf059bfb7971fd3a61 \
-    --hash=sha256:823737830364d0e2af8c3912a28ba971296181a07950873492ed94e12d28c405 \
-    --hash=sha256:c746876cdd8380be0c3e70966d4566855901ac9aaa5e4b9ccaa5ca5311457d11 \
-    --hash=sha256:fe7a549d10ca534797095586883a5c17d140d606747591258869c56e14d1b457 \
-    --hash=sha256:f058c786e7b0a9e7fa5e0b9f4422e0ccdd3bf3aa3053c18d77ed2a459bd9a45a \
-    --hash=sha256:98efc2d4983d5bb47662fe2d97b2c81b91566cb08b266490918b9c7d74a5ef64 \
-    --hash=sha256:e6b75091fa54a53db3927b4d1bc997c23c5ba6f87acdfe1ee5a92c38c6b2ed6a \
-    --hash=sha256:1ff13eed501e07e7fb26a4ea18a846b6e5d7de549b497025601fd9ccb7c1d123 \
-    --hash=sha256:798675317d0e4863a92a9a6bc5bd2490b5f6fef8c17b95f29e2e33f28bef9eca \
-    --hash=sha256:ed4fc66f23fe17c93a5d439230ca2d6b5f8eac7154198d327dbe8a16d98f3f10 \
-    --hash=sha256:522bfea92f3ef6207cadc7428bda1e7605dae0383b8065030e7b5d0266717b48 \
-    --hash=sha256:7897326cae660eee69d501cbfa950281a193fcf407393965e1bc07448e1cc35a \
-    --hash=sha256:b10d7910ae9d7920a5ff7816d794d99acbc361f7b16a0f017d4fa83ced8cb55e \
-    --hash=sha256:c554e6c9cf2d5ea1aba5979cc837b3649539ced0e18ece186f055450c86622e2
-pathspec==0.9.0; python_full_version >= "3.6.2" \
-    --hash=sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a \
-    --hash=sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1
-pendulum==2.1.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0") \
-    --hash=sha256:b6c352f4bd32dff1ea7066bd31ad0f71f8d8100b9ff709fb343f3b86cee43efe \
-    --hash=sha256:318f72f62e8e23cd6660dbafe1e346950281a9aed144b5c596b2ddabc1d19739 \
-    --hash=sha256:0731f0c661a3cb779d398803655494893c9f581f6488048b3fb629c2342b5394 \
-    --hash=sha256:3481fad1dc3f6f6738bd575a951d3c15d4b4ce7c82dce37cf8ac1483fde6e8b0 \
-    --hash=sha256:9702069c694306297ed362ce7e3c1ef8404ac8ede39f9b28b7c1a7ad8c3959e3 \
-    --hash=sha256:fb53ffa0085002ddd43b6ca61a7b34f2d4d7c3ed66f931fe599e1a531b42af9b \
-    --hash=sha256:c501749fdd3d6f9e726086bf0cd4437281ed47e7bca132ddb522f86a1645d360 \
-    --hash=sha256:c807a578a532eeb226150d5006f156632df2cc8c5693d778324b43ff8c515dd0 \
-    --hash=sha256:2d1619a721df661e506eff8db8614016f0720ac171fe80dda1333ee44e684087 \
-    --hash=sha256:f888f2d2909a414680a29ae74d0592758f2b9fcdee3549887779cd4055e975db \
-    --hash=sha256:e95d329384717c7bf627bf27e204bc3b15c8238fa8d9d9781d93712776c14002 \
-    --hash=sha256:4c9c689747f39d0d02a9f94fcee737b34a5773803a64a5fdb046ee9cac7442c5 \
-    --hash=sha256:1245cd0075a3c6d889f581f6325dd8404aca5884dea7223a5566c38aab94642b \
-    --hash=sha256:db0a40d8bcd27b4fb46676e8eb3c732c67a5a5e6bfab8927028224fbced0b40b \
-    --hash=sha256:f5e236e7730cab1644e1b87aca3d2ff3e375a608542e90fe25685dae46310116 \
-    --hash=sha256:de42ea3e2943171a9e95141f2eecf972480636e8e484ccffaf1e833929e9e052 \
-    --hash=sha256:7c5ec650cb4bec4c63a89a0242cc8c3cebcec92fcfe937c417ba18277d8560be \
-    --hash=sha256:33fb61601083f3eb1d15edeb45274f73c63b3c44a8524703dc143f4212bf3269 \
-    --hash=sha256:29c40a6f2942376185728c9a0347d7c0f07905638c83007e1d262781f1e6953a \
-    --hash=sha256:94b1fc947bfe38579b28e1cccb36f7e28a15e841f30384b5ad6c5e31055c85d7 \
-    --hash=sha256:b06a0ca1bfe41c990bbf0c029f0b6501a7f2ec4e38bfec730712015e8860f207
-platformdirs==2.0.2; python_full_version >= "3.6.1" \
-    --hash=sha256:0b9547541f599d3d242078ae60b927b3e453f0ad52f58b4d4bc3be86aed3ec41 \
-    --hash=sha256:3b00d081227d9037bbbca521a5787796b5ef5000faea1e43fd76f1d44b06fcfa
-pluggy==0.13.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
-    --hash=sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d \
-    --hash=sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0
-pre-commit==2.13.0; python_full_version >= "3.6.1" \
-    --hash=sha256:b679d0fddd5b9d6d98783ae5f10fd0c4c59954f375b70a58cbe1ce9bcf9809a4 \
-    --hash=sha256:764972c60693dc668ba8e86eb29654ec3144501310f7198742a767bec385a378
-py-cpuinfo==8.0.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" \
-    --hash=sha256:5f269be0e08e33fd959de96b34cd4aeeeacac014dd8305f70eb28d06de2345c5
-py==1.10.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
-    --hash=sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a \
-    --hash=sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3
-pycodestyle==2.7.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" \
-    --hash=sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068 \
-    --hash=sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef
-pydantic==1.8.2; python_full_version >= "3.6.1" \
-    --hash=sha256:05ddfd37c1720c392f4e0d43c484217b7521558302e7069ce8d318438d297739 \
-    --hash=sha256:a7c6002203fe2c5a1b5cbb141bb85060cbff88c2d78eccbc72d97eb7022c43e4 \
-    --hash=sha256:589eb6cd6361e8ac341db97602eb7f354551482368a37f4fd086c0733548308e \
-    --hash=sha256:10e5622224245941efc193ad1d159887872776df7a8fd592ed746aa25d071840 \
-    --hash=sha256:99a9fc39470010c45c161a1dc584997f1feb13f689ecf645f59bb4ba623e586b \
-    --hash=sha256:a83db7205f60c6a86f2c44a61791d993dff4b73135df1973ecd9eed5ea0bda20 \
-    --hash=sha256:41b542c0b3c42dc17da70554bc6f38cbc30d7066d2c2815a94499b5684582ecb \
-    --hash=sha256:ea5cb40a3b23b3265f6325727ddfc45141b08ed665458be8c6285e7b85bd73a1 \
-    --hash=sha256:18b5ea242dd3e62dbf89b2b0ec9ba6c7b5abaf6af85b95a97b00279f65845a23 \
-    --hash=sha256:234a6c19f1c14e25e362cb05c68afb7f183eb931dd3cd4605eafff055ebbf287 \
-    --hash=sha256:021ea0e4133e8c824775a0cfe098677acf6fa5a3cbf9206a376eed3fc09302cd \
-    --hash=sha256:e710876437bc07bd414ff453ac8ec63d219e7690128d925c6e82889d674bb505 \
-    --hash=sha256:ac8eed4ca3bd3aadc58a13c2aa93cd8a884bcf21cb019f8cfecaae3b6ce3746e \
-    --hash=sha256:4a03cbbe743e9c7247ceae6f0d8898f7a64bb65800a45cbdc52d65e370570820 \
-    --hash=sha256:8621559dcf5afacf0069ed194278f35c255dc1a1385c28b32dd6c110fd6531b3 \
-    --hash=sha256:8b223557f9510cf0bfd8b01316bf6dd281cf41826607eada99662f5e4963f316 \
-    --hash=sha256:244ad78eeb388a43b0c927e74d3af78008e944074b7d0f4f696ddd5b2af43c62 \
-    --hash=sha256:05ef5246a7ffd2ce12a619cbb29f3307b7c4509307b1b49f456657b43529dc6f \
-    --hash=sha256:54cd5121383f4a461ff7644c7ca20c0419d58052db70d8791eacbbe31528916b \
-    --hash=sha256:4be75bebf676a5f0f87937c6ddb061fa39cbea067240d98e298508c1bda6f3f3 \
-    --hash=sha256:fec866a0b59f372b7e776f2d7308511784dace622e0992a0b59ea3ccee0ae833 \
-    --hash=sha256:26464e57ccaafe72b7ad156fdaa4e9b9ef051f69e175dbbb463283000c05ab7b
-pyflakes==2.3.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" \
-    --hash=sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3 \
-    --hash=sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db
-pygal==2.4.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" \
-    --hash=sha256:27abab93cbc31e21f3c6bdecc05bda6cd3570cbdbd8297b7caa6904051b50d72 \
-    --hash=sha256:9204f05380b02a8a32f9bf99d310b51aa2a932cba5b369f7a4dc3705f0a4ce83
-pygaljs==1.0.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" \
-    --hash=sha256:d75e18cb21cc2cda40c45c3ee690771e5e3d4652bf57206f20137cf475c0dbe8 \
-    --hash=sha256:0b71ee32495dcba5fbb4a0476ddbba07658ad65f5675e4ad409baf154dec5111
-pygments==2.9.0; python_version >= "3.5" \
-    --hash=sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e \
-    --hash=sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f
-pymdown-extensions==7.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0") \
-    --hash=sha256:5bf93d1ccd8281948cd7c559eb363e59b179b5373478e8a7195cf4b78e3c11b6 \
-    --hash=sha256:8f415b21ee86d80bb2c3676f4478b274d0a8ccb13af672a4c86b9ffd22bd005c
-pyparsing==2.4.7; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6" \
-    --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b \
-    --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1
-pytest-benchmark==3.4.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0") \
-    --hash=sha256:40e263f912de5a81d891619032983557d62a3d85843f9a9f30b98baea0cd7b47 \
-    --hash=sha256:36d2b08c4882f6f997fd3126a3d6dfd70f3249cde178ed8bbc0b73db7c20f809
-pytest-cov==2.12.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0") \
-    --hash=sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7 \
-    --hash=sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a
-pytest==6.2.4; python_version >= "3.6" \
-    --hash=sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890 \
-    --hash=sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b
-python-dateutil==2.8.2; python_version >= "3.7.1" and python_version <= "3.9" and python_full_version >= "3.7.1" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") \
-    --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
-    --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
-pytz==2021.1; python_version >= "3.7.1" and python_version <= "3.9" and python_full_version >= "3.7.1" \
-    --hash=sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798 \
-    --hash=sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da
-pytzdata==2020.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" \
-    --hash=sha256:e1e14750bcf95016381e4d472bad004eef710f2d6417240904070b3d6654485f \
-    --hash=sha256:3efa13b335a00a8de1d345ae41ec78dd11c9f8807f522d39850f2dd828681540
-pyyaml-env-tag==0.1; python_version >= "3.6" \
-    --hash=sha256:af31106dec8a4d68c60207c1886031cbf839b68aa7abccdb19868200532c2069 \
-    --hash=sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb
-pyyaml==5.4.1; python_full_version >= "3.6.1" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6") \
-    --hash=sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922 \
-    --hash=sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393 \
-    --hash=sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8 \
-    --hash=sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185 \
-    --hash=sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253 \
-    --hash=sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc \
-    --hash=sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347 \
-    --hash=sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541 \
-    --hash=sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5 \
-    --hash=sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df \
-    --hash=sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018 \
-    --hash=sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63 \
-    --hash=sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa \
-    --hash=sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0 \
-    --hash=sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b \
-    --hash=sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf \
-    --hash=sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46 \
-    --hash=sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb \
-    --hash=sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247 \
-    --hash=sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc \
-    --hash=sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc \
-    --hash=sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696 \
-    --hash=sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77 \
-    --hash=sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183 \
-    --hash=sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122 \
-    --hash=sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6 \
-    --hash=sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10 \
-    --hash=sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db \
-    --hash=sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e
-regex==2021.7.6; python_full_version >= "3.6.2" \
-    --hash=sha256:e6a1e5ca97d411a461041d057348e578dc344ecd2add3555aedba3b408c9f874 \
-    --hash=sha256:6afe6a627888c9a6cfbb603d1d017ce204cebd589d66e0703309b8048c3b0854 \
-    --hash=sha256:ccb3d2190476d00414aab36cca453e4596e8f70a206e2aa8db3d495a109153d2 \
-    --hash=sha256:ed693137a9187052fc46eedfafdcb74e09917166362af4cc4fddc3b31560e93d \
-    --hash=sha256:99d8ab206a5270c1002bfcf25c51bf329ca951e5a169f3b43214fdda1f0b5f0d \
-    --hash=sha256:b85ac458354165405c8a84725de7bbd07b00d9f72c31a60ffbf96bb38d3e25fa \
-    --hash=sha256:3f5716923d3d0bfb27048242a6e0f14eecdb2e2a7fac47eda1d055288595f222 \
-    --hash=sha256:e5983c19d0beb6af88cb4d47afb92d96751fb3fa1784d8785b1cdf14c6519407 \
-    --hash=sha256:c92831dac113a6e0ab28bc98f33781383fe294df1a2c3dfd1e850114da35fd5b \
-    --hash=sha256:791aa1b300e5b6e5d597c37c346fb4d66422178566bbb426dd87eaae475053fb \
-    --hash=sha256:59506c6e8bd9306cd8a41511e32d16d5d1194110b8cfe5a11d102d8b63cf945d \
-    --hash=sha256:564a4c8a29435d1f2256ba247a0315325ea63335508ad8ed938a4f14c4116a5d \
-    --hash=sha256:59c00bb8dd8775473cbfb967925ad2c3ecc8886b3b2d0c90a8e2707e06c743f0 \
-    --hash=sha256:9a854b916806c7e3b40e6616ac9e85d3cdb7649d9e6590653deb5b341a736cec \
-    --hash=sha256:db2b7df831c3187a37f3bb80ec095f249fa276dbe09abd3d35297fc250385694 \
-    --hash=sha256:173bc44ff95bc1e96398c38f3629d86fa72e539c79900283afa895694229fe6a \
-    --hash=sha256:15dddb19823f5147e7517bb12635b3c82e6f2a3a6b696cc3e321522e8b9308ad \
-    --hash=sha256:2ddeabc7652024803666ea09f32dd1ed40a0579b6fbb2a213eba590683025895 \
-    --hash=sha256:f080248b3e029d052bf74a897b9d74cfb7643537fbde97fe8225a6467fb559b5 \
-    --hash=sha256:d8bbce0c96462dbceaa7ac4a7dfbbee92745b801b24bce10a98d2f2b1ea9432f \
-    --hash=sha256:edd1a68f79b89b0c57339bce297ad5d5ffcc6ae7e1afdb10f1947706ed066c9c \
-    --hash=sha256:422dec1e7cbb2efbbe50e3f1de36b82906def93ed48da12d1714cabcd993d7f0 \
-    --hash=sha256:cbe23b323988a04c3e5b0c387fe3f8f363bf06c0680daf775875d979e376bd26 \
-    --hash=sha256:0eb2c6e0fcec5e0f1d3bcc1133556563222a2ffd2211945d7b1480c1b1a42a6f \
-    --hash=sha256:1c78780bf46d620ff4fff40728f98b8afd8b8e35c3efd638c7df67be2d5cddbf \
-    --hash=sha256:bc84fb254a875a9f66616ed4538542fb7965db6356f3df571d783f7c8d256edd \
-    --hash=sha256:598c0a79b4b851b922f504f9f39a863d83ebdfff787261a5ed061c21e67dd761 \
-    --hash=sha256:875c355360d0f8d3d827e462b29ea7682bf52327d500a4f837e934e9e4656068 \
-    --hash=sha256:e586f448df2bbc37dfadccdb7ccd125c62b4348cb90c10840d695592aa1b29e0 \
-    --hash=sha256:2fe5e71e11a54e3355fa272137d521a40aace5d937d08b494bed4529964c19c4 \
-    --hash=sha256:6110bab7eab6566492618540c70edd4d2a18f40ca1d51d704f1d81c52d245026 \
-    --hash=sha256:4f64fc59fd5b10557f6cd0937e1597af022ad9b27d454e182485f1db3008f417 \
-    --hash=sha256:89e5528803566af4df368df2d6f503c84fbfb8249e6631c7b025fe23e6bd0cde \
-    --hash=sha256:2366fe0479ca0e9afa534174faa2beae87847d208d457d200183f28c74eaea59 \
-    --hash=sha256:f9392a4555f3e4cb45310a65b403d86b589adc773898c25a39184b1ba4db8985 \
-    --hash=sha256:2bceeb491b38225b1fee4517107b8491ba54fba77cf22a12e996d96a3c55613d \
-    --hash=sha256:f98dc35ab9a749276f1a4a38ab3e0e2ba1662ce710f6530f5b0a6656f1c32b58 \
-    --hash=sha256:319eb2a8d0888fa6f1d9177705f341bc9455a2c8aca130016e52c7fe8d6c37a3 \
-    --hash=sha256:eaf58b9e30e0e546cdc3ac06cf9165a1ca5b3de8221e9df679416ca667972035 \
-    --hash=sha256:4c9c3155fe74269f61e27617529b7f09552fbb12e44b1189cebbdb24294e6e1c \
-    --hash=sha256:8394e266005f2d8c6f0bc6780001f7afa3ef81a7a2111fa35058ded6fce79e4d
-six==1.16.0; python_full_version >= "3.6.1" \
-    --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254 \
-    --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926
-sqlalchemy-stubs==0.3 \
-    --hash=sha256:a3318c810697164e8c818aa2d90bac570c1a0e752ced3ec25455b309c0bee8fd \
-    --hash=sha256:ca1250605a39648cc433f5c70cb1a6f9fe0b60bdda4c51e1f9a2ab3651daadc8
-sqlalchemy==1.4.22; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0") \
-    --hash=sha256:488608953385d6c127d2dcbc4b11f8d7f2f30b89f6bd27c01b042253d985cc2f \
-    --hash=sha256:5d856cc50fd26fc8dd04892ed5a5a3d7eeb914fea2c2e484183e2d84c14926e0 \
-    --hash=sha256:a00d9c6d3a8afe1d1681cd8a5266d2f0ed684b0b44bada2ca82403b9e8b25d39 \
-    --hash=sha256:5908ea6c652a050d768580d01219c98c071e71910ab8e7b42c02af4010608397 \
-    --hash=sha256:b7fb937c720847879c7402fe300cfdb2aeff22349fa4ea3651bca4e2d6555939 \
-    --hash=sha256:9bfe882d5a1bbde0245dca0bd48da0976bd6634cf2041d2fdf0417c5463e40e5 \
-    --hash=sha256:eedd76f135461cf237534a6dc0d1e0f6bb88a1dc193678fab48a11d223462da5 \
-    --hash=sha256:6a16c7c4452293da5143afa3056680db2d187b380b3ef4d470d4e29885720de3 \
-    --hash=sha256:44d23ea797a5e0be71bc5454b9ae99158ea0edc79e2393c6e9a2354de88329c0 \
-    --hash=sha256:a5e14cb0c0a4ac095395f24575a0e7ab5d1be27f5f9347f1762f21505e3ba9f1 \
-    --hash=sha256:bc34a007e604091ca3a4a057525efc4cefd2b7fe970f44d20b9cfa109ab1bddb \
-    --hash=sha256:756f5d2f5b92d27450167247fb574b09c4cd192a3f8c2e493b3e518a204ee543 \
-    --hash=sha256:9fcbb4b4756b250ed19adc5e28c005b8ed56fdb5c21efa24c6822c0575b4964d \
-    --hash=sha256:09dbb4bc01a734ccddbf188deb2a69aede4b3c153a72b6d5c6900be7fb2945b1 \
-    --hash=sha256:f028ef6a1d828bc754852a022b2160e036202ac8658a6c7d34875aafd14a9a15 \
-    --hash=sha256:68393d3fd31469845b6ba11f5b4209edbea0b58506be0e077aafbf9aa2e21e11 \
-    --hash=sha256:891927a49b2363a4199763a9d436d97b0b42c65922a4ea09025600b81a00d17e \
-    --hash=sha256:fd2102a8f8a659522719ed73865dff3d3cc76eb0833039dc473e0ad3041d04be \
-    --hash=sha256:4014978de28163cd8027434916a92d0f5bb1a3a38dff5e8bf8bff4d9372a9117 \
-    --hash=sha256:f814d80844969b0d22ea63663da4de5ca1c434cfbae226188901e5d368792c17 \
-    --hash=sha256:d09a760b0a045b4d799102ae7965b5491ccf102123f14b2a8cc6c01d1021a2d9 \
-    --hash=sha256:26daa429f039e29b1e523bf763bfab17490556b974c77b5ca7acb545b9230e9a \
-    --hash=sha256:12bac5fa1a6ea870bdccb96fe01610641dd44ebe001ed91ef7fcd980e9702db5 \
-    --hash=sha256:39b5d36ab71f73c068cdcf70c38075511de73616e6c7fdd112d6268c2704d9f5 \
-    --hash=sha256:5102b9face693e8b2db3b2539c7e1a5d9a5b4dc0d79967670626ffd2f710d6e6 \
-    --hash=sha256:c9373ef67a127799027091fa53449125351a8c943ddaa97bec4e99271dbb21f4 \
-    --hash=sha256:36a089dc604032d41343d86290ce85d4e6886012eea73faa88001260abf5ff81 \
-    --hash=sha256:b48148ceedfb55f764562e04c00539bb9ea72bf07820ca15a594a9a049ff6b0e \
-    --hash=sha256:1fdae7d980a2fa617d119d0dc13ecb5c23cc63a8b04ffcb5298f2c59d86851e9 \
-    --hash=sha256:ec1be26cdccd60d180359a527d5980d959a26269a2c7b1b327a1eea0cab37ed8
-sqlparse==0.4.1; python_version >= "3.5" \
-    --hash=sha256:017cde379adbd6a1f15a61873f43e8274179378e95ef3fede90b5aa64d304ed0 \
-    --hash=sha256:0f91fd2e829c44362cbcfab3e9ae12e22badaa8a29ad5ff599f9ec109f0454e8
-toastedmarshmallow==2.15.2.post1 \
-    --hash=sha256:aad7c89720a27d6362e1362394ceaedf5e1648aba4506c1971da35b3642810e9
-toml==0.10.2; python_full_version >= "3.6.1" and python_version >= "3.6" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") \
-    --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
-    --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
-tomli==1.1.0; python_version >= "3.6" and python_full_version >= "3.6.2" \
-    --hash=sha256:f4a182048010e89cbec0ae4686b21f550a7f2903f665e34a6de58ec15424f919 \
-    --hash=sha256:33d7984738f8bb699c9b0a816eb646a8178a69eaa792d258486776a5d21b8ca5
-typed-ast==1.4.3; python_version < "3.8" and python_version >= "3.5" and python_full_version >= "3.6.2" \
-    --hash=sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6 \
-    --hash=sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075 \
-    --hash=sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528 \
-    --hash=sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428 \
-    --hash=sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3 \
-    --hash=sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f \
-    --hash=sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341 \
-    --hash=sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace \
-    --hash=sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f \
-    --hash=sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363 \
-    --hash=sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7 \
-    --hash=sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266 \
-    --hash=sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e \
-    --hash=sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04 \
-    --hash=sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899 \
-    --hash=sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c \
-    --hash=sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805 \
-    --hash=sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a \
-    --hash=sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff \
-    --hash=sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41 \
-    --hash=sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39 \
-    --hash=sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927 \
-    --hash=sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40 \
-    --hash=sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3 \
-    --hash=sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4 \
-    --hash=sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0 \
-    --hash=sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3 \
-    --hash=sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808 \
-    --hash=sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c \
-    --hash=sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65
-typing-extensions==3.10.0.0; python_full_version >= "3.6.2" and python_version >= "3.6" and python_version < "3.8" \
-    --hash=sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497 \
-    --hash=sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84 \
-    --hash=sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342
-ujson==3.2.0; python_version >= "3.5" \
-    --hash=sha256:437e051a3e292ddbd5b4682f9b6c3e2ea4cd059d0d75bc9f8314349d63cbb015 \
-    --hash=sha256:a27ea44406100a97fb0fcc0b18dcdaf324824e722a00856a2992fafc65779351 \
-    --hash=sha256:6f7c24dabb0ff0ff43744d18211af6035ef37197f530c13edf704e627da7251d \
-    --hash=sha256:5ae6f599ef7c01ef626697f9e15e9d4e2a186ab4c0593ddb529b86866b562efb \
-    --hash=sha256:59048958793e0b0489449a414e2fbe54644457be1dd882b99a4fe16158632af1 \
-    --hash=sha256:a476525862a394018a7a3438c86596815b84518b2744184444fc6f8b0e3e4aee \
-    --hash=sha256:2050c7f1ce72055f1b6fba29e4694ccf4509917d3be3ed6f3543ef3ff00eec4a \
-    --hash=sha256:fda324ca055e671eae46e8fc32b46fab20eb251d3e6e22beb67f71f1d240b0b4 \
-    --hash=sha256:0bdc62a1543d697e9c649ac0ac41e0d076a7b886d6b45f9f21971e25b90a2b27 \
-    --hash=sha256:d0ad63fc88d4e4cb7630f59aacd742256804a4cee447e9589e55957107a469b7 \
-    --hash=sha256:66d47eabb4f0e12b5784b1a49c59bc6f32e91e18e02f2a43c5e91e2f6ad9cc60 \
-    --hash=sha256:253edfe274538bb1060ab8877d51fc75e416047d5fab5340454a48b971f30612 \
-    --hash=sha256:6ee651c0210a67e3a72367de53ccac83b623913214e7c75015caadfad2b7e0dc \
-    --hash=sha256:0784f35f2ace41ed55c435ee11f9d9877cf3e6ff03c8850f87504cb93e9a9469 \
-    --hash=sha256:812748c8de041f1ef5e9b37f33121c0c7390055fa5f12215b3d06a63b1c055a2 \
-    --hash=sha256:17460d88dd4b9630e449e5d29b97301e6dbbbedbf46a6f95f3b2cb7e1333e6ea \
-    --hash=sha256:2d50cb3d87d4aabe6dbeb6ef79025bf9fdf350c4355c24819dc5c5cc38bad3dc \
-    --hash=sha256:7060105de892cada2f01bd072d33b2421b4eefd32536207c1c9f2ade18656139 \
-    --hash=sha256:7b6496b3e2bc396628f114fd96ec41655b10c84adececc0ef8cf1c2329dae36c \
-    --hash=sha256:782bdf016da793a3bf138e50ed973428e59006b8d73a9e1911bc6207c6b79fff \
-    --hash=sha256:abb1996ba1c1d2faf5b1e38efa97da7f64e5373a31f705b96fe0587f5f778db4
-virtualenv==20.6.0; python_full_version >= "3.6.1" \
-    --hash=sha256:e4fc84337dce37ba34ef520bf2d4392b392999dbe47df992870dc23230f6b758 \
-    --hash=sha256:51df5d8a2fad5d1b13e088ff38a433475768ff61f202356bb9812c454c20ae45
-watchdog==2.1.3; python_version >= "3.6" \
-    --hash=sha256:9628f3f85375a17614a2ab5eac7665f7f7be8b6b0a2a228e6f6a2e91dd4bfe26 \
-    --hash=sha256:acc4e2d5be6f140f02ee8590e51c002829e2c33ee199036fcd61311d558d89f4 \
-    --hash=sha256:85b851237cf3533fabbc034ffcd84d0fa52014b3121454e5f8b86974b531560c \
-    --hash=sha256:a12539ecf2478a94e4ba4d13476bb2c7a2e0a2080af2bb37df84d88b1b01358a \
-    --hash=sha256:6fe9c8533e955c6589cfea6f3f0a1a95fb16867a211125236c82e1815932b5d7 \
-    --hash=sha256:d9456f0433845e7153b102fffeb767bde2406b76042f2216838af3b21707894e \
-    --hash=sha256:fd8c595d5a93abd441ee7c5bb3ff0d7170e79031520d113d6f401d0cf49d7c8f \
-    --hash=sha256:0bcfe904c7d404eb6905f7106c54873503b442e8e918cc226e1828f498bdc0ca \
-    --hash=sha256:bf84bd94cbaad8f6b9cbaeef43080920f4cb0e61ad90af7106b3de402f5fe127 \
-    --hash=sha256:b8ddb2c9f92e0c686ea77341dcb58216fa5ff7d5f992c7278ee8a392a06e86bb \
-    --hash=sha256:8805a5f468862daf1e4f4447b0ccf3acaff626eaa57fbb46d7960d1cf09f2e6d \
-    --hash=sha256:3e305ea2757f81d8ebd8559d1a944ed83e3ab1bdf68bcf16ec851b97c08dc035 \
-    --hash=sha256:431a3ea70b20962e6dee65f0eeecd768cd3085ea613ccb9b53c8969de9f6ebd2 \
-    --hash=sha256:e4929ac2aaa2e4f1a30a36751160be391911da463a8799460340901517298b13 \
-    --hash=sha256:201cadf0b8c11922f54ec97482f95b2aafca429c4c3a4bb869a14f3c20c32686 \
-    --hash=sha256:3a7d242a7963174684206093846537220ee37ba9986b824a326a8bb4ef329a33 \
-    --hash=sha256:54e057727dd18bd01a3060dbf5104eb5a495ca26316487e0f32a394fd5fe725a \
-    --hash=sha256:b5fc5c127bad6983eecf1ad117ab3418949f18af9c8758bd10158be3647298a9 \
-    --hash=sha256:44acad6f642996a2b50bb9ce4fb3730dde08f23e79e20cd3d8e2a2076b730381 \
-    --hash=sha256:0bcdf7b99b56a3ae069866c33d247c9994ffde91b620eaf0306b27e099bd1ae0 \
-    --hash=sha256:e5236a8e8602ab6db4b873664c2d356c365ab3cac96fbdec4970ad616415dd45
-wcmatch==8.2; python_version >= "3.6" \
-    --hash=sha256:9146b1ab9354e0797ef6ef69bc89cb32cb9f46d1b9eeef69c559aeec8f3bffb6 \
-    --hash=sha256:4d54ddb506c90b5a5bba3a96a1cfb0bb07127909e19046a71d689ddfb18c3617
-zipp==3.5.0; python_version < "3.8" and python_version >= "3.6" \
-    --hash=sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3 \
-    --hash=sha256:f5812b1e007e48cff63449a5e9f4e7ebea716b4111f9c4f9a645f91d579bf0c4
+appdirs==1.4.4; python_full_version >= "3.6.2"
+atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.4.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
+attrs==21.2.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+black==21.7b0; python_full_version >= "3.6.2"
+bracex==2.1.1; python_version >= "3.6"
+click==8.0.1; python_version >= "3.6" and python_full_version >= "3.6.2"
+colorama==0.4.4; sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.6.2" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") and platform_system == "Windows"
+coverage==5.5; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
+django==2.2.24; python_version >= "3.5"
+djangorestframework==3.12.4; python_version >= "3.5"
+dnspython==2.1.0; python_full_version >= "3.6.1" and python_version >= "3.6"
+email-validator==1.1.3; python_full_version >= "3.6.1"
+fastjsonschema==2.15.1
+flake8==3.9.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+future-typing==0.4.1; python_version >= "3.6"
+ghp-import==2.0.1; python_version >= "3.6"
+greenlet==1.1.0; python_version >= "3" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3"
+idna==3.2; python_full_version >= "3.6.1" and python_version >= "3.5"
+importlib-metadata==4.6.1; python_version < "3.8" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.6.0" and python_version < "3.8" and python_version >= "3.6") and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.5.0" and python_version < "3.8" and python_version >= "3.6") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.4.0" and python_version >= "3.6" and python_version < "3.8") and python_full_version >= "3.6.2"
+inflection==0.5.1; python_version >= "3.5"
+iniconfig==1.1.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+jinja2==3.0.1; python_version >= "3.6"
+markdown==3.3.4; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+markupsafe==2.0.1; python_version >= "3.6"
+marshmallow==3.13.0; python_version >= "3.5"
+mccabe==0.6.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+mergedeep==1.3.4; python_version >= "3.6"
+mkdocs-awesome-pages-plugin==2.5.0; python_version >= "3.5"
+mkdocs-material-extensions==1.0.1; python_version >= "3.5"
+mkdocs-material==5.5.14
+mkdocs==1.2.2; python_version >= "3.6"
+mypy-extensions==0.4.3; python_version >= "3.5" and python_full_version >= "3.6.2"
+mypy==0.910; python_version >= "3.5"
+numpy==1.21.1; python_version >= "3.7.1" and python_version <= "3.9" and python_full_version >= "3.7.1"
+packaging==21.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+pandas==1.3.0; python_version >= "3.7.1" and python_version <= "3.9"
+pathspec==0.9.0; python_full_version >= "3.6.2"
+pendulum==2.1.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+pluggy==0.13.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+py-cpuinfo==8.0.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+py==1.10.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+pycodestyle==2.7.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+pydantic==1.8.2; python_full_version >= "3.6.1"
+pyflakes==2.3.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+pygal==2.4.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+pygaljs==1.0.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+pygments==2.9.0; python_version >= "3.5"
+pymdown-extensions==7.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+pyparsing==2.4.7; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
+pytest-benchmark==3.4.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+pytest-cov==2.12.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+pytest==6.2.4; python_version >= "3.6"
+python-dateutil==2.8.2; python_version >= "3.7.1" and python_version <= "3.9" and python_full_version >= "3.7.1" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6")
+pytz==2021.1; python_version >= "3.7.1" and python_version <= "3.9" and python_full_version >= "3.7.1"
+pytzdata==2020.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+pyyaml-env-tag==0.1; python_version >= "3.6"
+pyyaml==5.4.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+regex==2021.7.6; python_full_version >= "3.6.2"
+six==1.16.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+sqlalchemy==1.4.22; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
+sqlparse==0.4.1; python_version >= "3.5"
+toastedmarshmallow==2.15.2.post1
+toml==0.10.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+tomli==1.1.0; python_version >= "3.6" and python_full_version >= "3.6.2"
+typed-ast==1.4.3; python_version < "3.8" and python_version >= "3.5" and python_full_version >= "3.6.2"
+typing-extensions==3.10.0.0; python_full_version >= "3.6.2" and python_version >= "3.6" and python_version < "3.8"
+ujson==3.2.0; python_version >= "3.5"
+watchdog==2.1.3; python_version >= "3.6"
+wcmatch==8.2; python_version >= "3.6"
+zipp==3.5.0; python_version < "3.8" and python_version >= "3.6"

--- a/tests/3p/test_pandas.py
+++ b/tests/3p/test_pandas.py
@@ -1,0 +1,35 @@
+# flake8: noqa
+
+import sys
+
+import pytest
+import typic
+
+
+def has_pandas():
+    try:
+        import pandas
+
+        return True
+    except (ModuleNotFoundError, ImportError):
+        return False
+
+
+@pytest.mark.skipif(
+    "not has_pandas()", reason=f"Pandas isn't installed. (Python {sys.version})"
+)
+def test_transmute_pandas_series():
+    import pandas
+
+    transmuted = typic.transmute(pandas.Series, [])
+    assert isinstance(transmuted, pandas.Series)
+
+
+@pytest.mark.skipif(
+    "not has_pandas()", reason=f"Pandas isn't installed. (Python {sys.version})"
+)
+def test_transmute_pandas_dataframe():
+    import pandas
+
+    transmuted = typic.transmute(pandas.DataFrame, {})
+    assert isinstance(transmuted, pandas.DataFrame)

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -20,7 +20,7 @@ executable_modules = ("success",)
 
 
 @pytest.mark.skipif(
-    "sys.version_info > (3, 8)", reason="Mypy doesn't yet support Python 3.9."
+    "sys.version_info > (3, 9)", reason="Mypy doesn't yet support Python 3.10."
 )
 @pytest.mark.parametrize("config_filename,python_filename,output_filename", cases)
 def test_mypy_results(config_filename, python_filename, output_filename):

--- a/tests/objects.py
+++ b/tests/objects.py
@@ -13,7 +13,8 @@ except ImportError:
 
 import inflection
 import typic
-import pandas
+
+# import pandas
 import pydantic
 import sqlalchemy
 from sqlalchemy.ext.declarative import declarative_base
@@ -364,11 +365,6 @@ class Source:
 @typic.klass
 class Dest:
     test: typing.Optional[str] = None
-
-
-@typic.klass
-class DFClass:
-    df: pandas.DataFrame = None
 
 
 @typic.klass

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -11,7 +11,6 @@ import uuid
 from collections import defaultdict
 from operator import attrgetter
 
-import pandas
 import pendulum
 import pytest
 
@@ -240,24 +239,6 @@ def test_transmute_subclassed_enum_with_default():
 def test_transmute_collection_metas(annotation, value, expected):
     transmuted = transmute(annotation, value)
     assert transmuted == expected
-
-
-@pytest.mark.parametrize(
-    argnames=("annotation", "value", "expected"),
-    argvalues=[
-        (pandas.DataFrame, {}, pandas.DataFrame()),
-        (pandas.Series, [], pandas.Series()),
-        (objects.DFClass, {}, pandas.DataFrame()),
-        (objects.DFClass, None, None),
-    ],
-)
-def test_transmute_pandas(annotation, value, expected):
-    if annotation is objects.DFClass:
-        transmuted = objects.DFClass(value).df
-    else:
-        transmuted = transmute(annotation, value)
-        assert isinstance(transmuted, annotation)
-    assert transmuted == expected if expected is None else expected.equals(transmuted)
 
 
 def test_default_none():
@@ -549,7 +530,6 @@ def test_eval_invalid():
     argvalues=[
         (typed(objects.Data)("foo"), "foo", 1, str),
         (typed(objects.NoParams)(), "var", 1, str),
-        (objects.DFClass(), "df", {}, pandas.DataFrame),
     ],
     ids=objects.get_id,
 )

--- a/typic/checks.py
+++ b/typic/checks.py
@@ -94,6 +94,7 @@ __all__ = (
     "istupletype",
     "istypeddict",
     "istypedtuple",
+    "isuniontype",
     "isuuidtype",
     "iswriteonly",
     "should_unwrap",
@@ -249,8 +250,13 @@ def isoptionaltype(obj: Type[ObjectT]) -> TypeGuard[Optional]:
             type(None),
             None,
         }  # noqa: E721 - we don't know what args[-1] is, so this is safer
-        and getattr(obj, "__origin__", obj) in {Optional, Union, Literal}
+        and util.get_name(util.origin(obj)) in {"Optional", "Union", "Literal"}
     )
+
+
+@lru_cache(maxsize=None)
+def isuniontype(obj: Type[ObjectT]) -> TypeGuard[Union]:
+    return util.get_name(util.origin(obj)) == "Union"
 
 
 @lru_cache(maxsize=None)
@@ -747,7 +753,7 @@ def istypeddict(obj: Type[ObjectT]) -> TypeGuard[Type[TypedDict]]:
     return (
         inspect.isclass(obj)
         and dict in {*inspect.getmro(obj)}
-        and hasattr(obj, "__annotations__")
+        and hasattr(obj, "__total__")
     )
 
 

--- a/typic/compat.py
+++ b/typic/compat.py
@@ -13,9 +13,9 @@ from typing import (
 )
 
 try:
-    from typing import Final, TypedDict, Literal, Protocol, TypeGuard  # type: ignore
+    from typing import Final, TypedDict, Literal, Protocol, TypeGuard, get_origin, get_args  # type: ignore
 except ImportError:  # pragma: nocover
-    from typing_extensions import Final, TypedDict, Literal, Protocol, TypeGuard  # type: ignore
+    from typing_extensions import Final, TypedDict, Literal, Protocol, TypeGuard, get_origin, get_args  # type: ignore
 try:
     from typing import ForwardRef  # type: ignore
 except ImportError:  # pragma: nocover
@@ -94,6 +94,19 @@ if TYPE_CHECKING:
 else:
     from functools import lru_cache
 
+
+if sys.version_info >= (3, 10):  # pragma: nocover
+    DATACLASS_KW_ONLY = DATACLASS_MATCH_ARGS = DATACLASS_NATIVE_SLOTS = True
+    from dataclasses import KW_ONLY  # type: ignore
+
+else:
+    DATACLASS_KW_ONLY = DATACLASS_MATCH_ARGS = DATACLASS_NATIVE_SLOTS = False
+
+    class _KW_ONLY_TYPE:
+        pass
+
+    KW_ONLY = _KW_ONLY_TYPE()
+
 __all__ = (
     "Final",
     "TypedDict",
@@ -105,4 +118,8 @@ __all__ = (
     "sqla_registry",
     "evaluate_forwardref",
     "lru_cache",
+    "DATACLASS_KW_ONLY",
+    "DATACLASS_MATCH_ARGS",
+    "DATACLASS_NATIVE_SLOTS",
+    "KW_ONLY",
 )

--- a/typic/constraints/factory.py
+++ b/typic/constraints/factory.py
@@ -27,6 +27,7 @@ from typing import (
 )
 
 from typic.checks import (
+    isuniontype,
     isoptionaltype,
     isbuiltintype,
     isconstrained,
@@ -181,7 +182,7 @@ def _resolve_args(
         arg = largs.popleft()
         if arg in {Any, Ellipsis}:
             continue
-        if origin(arg) is Union:
+        if isuniontype(arg):
             c = _from_union(arg, cls=cls, nullable=nullable)
             # just extend the outer multi constraints if that's what we're building
             if isinstance(c, MultiConstraints) and multi:
@@ -274,7 +275,7 @@ def _resolve_params(
         nullable = p.default in (None, Ellipsis) or isoptionaltype(anno)
         if anno in {Any, Ellipsis, p.empty}:
             continue
-        if origin(anno) is Union:
+        if isuniontype(anno) and not isforwardref(anno):
             items[name] = _from_union(anno, nullable=nullable, name=name, cls=cls)
             continue
         else:

--- a/typic/ext/schema/schema.py
+++ b/typic/ext/schema/schema.py
@@ -26,7 +26,7 @@ from typic.serde.resolver import resolver
 from typic.serde.common import SerdeProtocol, Annotation
 from typic.compat import Final, TypedDict, ForwardRef, Literal
 from typic.util import get_args, origin, get_name
-from typic.checks import istypeddict, isnamedtuple, isliteral
+from typic.checks import istypeddict, isnamedtuple, isliteral, isuniontype
 from typic.types.frozendict import FrozenDict
 
 from .field import (  # type: ignore
@@ -280,7 +280,7 @@ class SchemaBuilder:
         # `use` is the based annotation we will use for building the schema
         use = getattr(anno.origin, "__parent__", anno.origin)
         # This is a flat optional, handle it separately from the Union block.
-        use = anno.resolved if use is Union and not anno.args else use
+        use = anno.resolved if isuniontype(use) and not anno.args else use
         # If there's not a static annotation, short-circuit the rest of the checks.
         schema: SchemaFieldT
         if use in {Any, anno.EMPTY}:
@@ -292,7 +292,7 @@ class SchemaBuilder:
         # {'type': ['string', 'integer']} ==
         #   {'anyOf': [{'type': 'string'}, {'type': 'integer'}]}
         # We don't care about syntactic sugar if it's functionally the same.
-        if use is Union:
+        if isuniontype(use):
             return self._handle_union(anno=anno, ro=ro, wo=wo, name=name, parent=parent)
 
         self.__stack.add(anno)

--- a/typic/klass.py
+++ b/typic/klass.py
@@ -15,6 +15,7 @@ from typing import (
 )
 
 from typic.api import wrap_cls, ObjectT
+from typic.compat import DATACLASS_NATIVE_SLOTS, DATACLASS_KW_ONLY, DATACLASS_MATCH_ARGS
 from typic.types import freeze
 from typic.util import slotted
 from .serde.common import SerdeFlags
@@ -50,6 +51,7 @@ class Field(dataclasses.Field):
 
     def __init__(
         self,
+        *,
         default: Union[ObjectT, dataclasses._MISSING_TYPE],
         default_factory: Union[FactoryT, dataclasses._MISSING_TYPE],
         init: bool,
@@ -59,16 +61,17 @@ class Field(dataclasses.Field):
         metadata: Optional[Mapping[Hashable, Any]],
         exclude: bool = False,
         name: str = None,
+        **kwargs,
     ):
         super(Field, self).__init__(
-            default, default_factory, init, repr, hash, compare, metadata  # type: ignore
+            default, default_factory, init, repr, hash, compare, metadata, **kwargs  # type: ignore
         )
         self.exclude = exclude
         self.external_name = name
 
     @classmethod
     def from_field(cls: Type["Field"], f: dataclasses.Field) -> "Field":
-        tf = cls(
+        kwargs = dict(
             default=f.default,
             default_factory=f.default_factory,  # type: ignore
             init=f.init,
@@ -77,12 +80,17 @@ class Field(dataclasses.Field):
             compare=f.compare,
             metadata=f.metadata,  # type: ignore
         )
+        if DATACLASS_KW_ONLY:
+            kwargs["kw_only"] = f.kw_only  # type: ignore
+
+        tf = cls(**kwargs)
         tf.name = f.name
         tf.type = f.type
         return tf
 
 
 def field(
+    *,
     default: Union[ObjectT, dataclasses._MISSING_TYPE] = dataclasses.MISSING,
     default_factory: Union[FactoryT, dataclasses._MISSING_TYPE] = dataclasses.MISSING,
     init: bool = True,
@@ -92,8 +100,9 @@ def field(
     metadata: Mapping[Hashable, Any] = None,
     exclude: bool = False,
     name: str = None,
+    kw_only: bool = False,
 ) -> Field:
-    return Field(
+    kwargs = dict(
         default=default,
         default_factory=default_factory,
         init=init,
@@ -104,6 +113,9 @@ def field(
         exclude=exclude,
         name=name,
     )
+    if DATACLASS_KW_ONLY:
+        kwargs["kw_only"] = kw_only
+    return Field(**kwargs)  # type: ignore
 
 
 def make_typedclass(
@@ -119,6 +131,8 @@ def make_typedclass(
     strict: bool = False,
     jsonschema: bool = False,
     slots: bool = False,
+    kw_only: bool = False,
+    match_args: bool = True,
     serde: SerdeFlags = None,
 ):
     """A convenience function for generating a dataclass with type-coercion.
@@ -135,8 +149,7 @@ def make_typedclass(
     :py:func:`dataclasses.dataclass`
     """
     # Make the base dataclass.
-    dcls = dataclasses.dataclass(  # type: ignore
-        cls,
+    kwargs = dict(
         init=init,
         repr=repr,
         eq=eq,
@@ -144,8 +157,16 @@ def make_typedclass(
         unsafe_hash=unsafe_hash,
         frozen=frozen,
     )
-    if slots:
-        dcls = slotted(dcls)
+    if DATACLASS_KW_ONLY:
+        kwargs["kw_only"] = kw_only
+    if DATACLASS_MATCH_ARGS:
+        kwargs["match_args"] = match_args
+    if DATACLASS_NATIVE_SLOTS:
+        dcls = dataclasses.dataclass(cls, **kwargs, slots=slots)  # type: ignore
+    else:
+        dcls = dataclasses.dataclass(cls, **kwargs)  # type: ignore
+        if slots:
+            dcls = slotted(dcls)
 
     fields = [
         f if isinstance(f, Field) else Field.from_field(f)
@@ -178,6 +199,8 @@ def klass(
     strict: bool = False,
     jsonschema: bool = True,
     slots: bool = False,
+    kw_only: bool = False,
+    match_args: bool = True,
     serde: SerdeFlags = None,
 ):
     """A convenience decorator for generating a dataclass with type-coercion.
@@ -219,6 +242,8 @@ def klass(
             strict=strict,
             jsonschema=jsonschema,
             slots=slots,
+            kw_only=kw_only,
+            match_args=match_args,
             serde=serde,
         )
 

--- a/typic/serde/des.py
+++ b/typic/serde/des.py
@@ -719,7 +719,7 @@ class DesFactory:
             with main.f(func_name, main.param(f"{self.VNAME}")) as func:
                 if origin not in self.UNRESOLVABLE:
                     self._set_checks(func, anno_name, annotation)
-                    if origin is Union:
+                    if checks.isuniontype(origin):
                         self._build_union_des(func, annotation, namespace)
                     elif checks.isdatetype(origin):
                         self._build_date_des(func, anno_name, annotation)

--- a/typic/util.py
+++ b/typic/util.py
@@ -9,6 +9,7 @@ import functools
 import inspect
 import sys
 import types
+import warnings
 from datetime import date, datetime, timedelta, time
 from threading import RLock
 from types import MappingProxyType, MemberDescriptorType
@@ -471,6 +472,9 @@ def _safe_get_type_hints(annotation: Union[Type, Callable]) -> Dict[str, Type[An
         except NameError:
             # this is ok, we deal with it later.
             pass
+        except TypeError as e:
+            warnings.warn(f"Couldn't evaluate type {value!r}: {e}")
+            value = Any
         annotations[name] = value
     return annotations
 

--- a/typic/util.py
+++ b/typic/util.py
@@ -227,8 +227,8 @@ def get_name(obj: Union[Type, ForwardRef, Callable]) -> str:
     >>> typic.get_name(dict)
     'dict'
     """
-    if getattr(obj, "__module__") == "typing":
-        return str(getattr(obj, "__origin__", obj)).rpartition(".")[-1]
+    if getattr(obj, "__module__", "") == "typing":
+        return str(obj).rpartition(".")[-1].partition("[")[0]
     if hasattr(obj, "_name") and not hasattr(obj, "__name__"):
         return obj._name or str(obj)  # type: ignore
     elif isinstance(obj, ForwardRef):

--- a/typic/util.py
+++ b/typic/util.py
@@ -227,6 +227,8 @@ def get_name(obj: Union[Type, ForwardRef, Callable]) -> str:
     >>> typic.get_name(dict)
     'dict'
     """
+    if getattr(obj, "__module__") == "typing":
+        return str(getattr(obj, "__origin__", obj)).rpartition(".")[-1]
     if hasattr(obj, "_name") and not hasattr(obj, "__name__"):
         return obj._name or str(obj)  # type: ignore
     elif isinstance(obj, ForwardRef):
@@ -238,6 +240,8 @@ def get_name(obj: Union[Type, ForwardRef, Callable]) -> str:
 
 @lru_cache(maxsize=None)
 def get_qualname(obj: Type) -> str:
+    if getattr(obj, "__module__") == "typing":
+        return str(getattr(obj, "__origin__", obj))
     if hasattr(obj, "_name") and not hasattr(obj, "__name__"):
         return repr(obj)
     elif isinstance(obj, ForwardRef):


### PR DESCRIPTION
This is an attempt to add support for Python 3.10.

There were quite a few changes to typing runtime and internals that had cascading effects on typical:

- builtins have empty `__annotations__`.
- TypedDict, NamedTuple are functions, not classes.
- The new Union operator is a completely new type `types.Union` and is not the same as `typing.Union`.

Additionally:
- dataclasses got a few shiny updates (kw_only, match_args, slots)
- Pandas can't be installed on python 3.10



Resolves #162 