### PR TITLE
Optimize signature binding and other fixups

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
         ./.github/ubuntu-install.sh
 
     - name: Install Poetry
-      uses: abatilo/actions-poetry@v2.0.0
+      uses: abatilo/actions-poetry@v2.1.3
 
     - name: Cache Poetry virtualenv
       uses: actions/cache@v1

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Poetry (Platform ${{ matrix.os }})
-      uses: abatilo/actions-poetry@v2.0.0
+      uses: abatilo/actions-poetry@v2.1.3
     - name: Build ${{ matrix.os }} binaries
       run: poetry build
     - name: Store dist artifacts
@@ -37,7 +37,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Install Poetry
-      uses: abatilo/actions-poetry@v2.0.0
+      uses: abatilo/actions-poetry@v2.1.3
     - name: Build sdist
       run: poetry build -f sdist
     - name: Store dist artifacts
@@ -61,7 +61,7 @@ jobs:
         name: typical-dist
         path: dist
     - name: Install Poetry
-      uses: abatilo/actions-poetry@v2.0.0
+      uses: abatilo/actions-poetry@v2.1.3
     - name: Publish to PyPI
       run: poetry publish -u $PYPI_USERNAME -p $PYPI_PASSWORD
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10.0-alpha - 3.10"]
+        poetry-version: ["1.1.8"]
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
@@ -36,8 +37,9 @@ jobs:
         ./.github/macos-install.sh
 
     - name: Install Poetry
-      uses: abatilo/actions-poetry@v2.0.0
-
+      uses: abatilo/actions-poetry@v2.1.3
+      with:
+        poetry-version: ${{ matrix.poetry-version }}
     - name: Cache Poetry virtualenv
       uses: actions/cache@v1
       id: cache
@@ -50,7 +52,9 @@ jobs:
     - name: Set Poetry config
       run: |
         poetry config virtualenvs.in-project true
-
+    - name: Use legacy installer (Poetry+py3.10)
+      run: |
+        poetry config experimental.new-installer false
     - name: Install Dependencies
       if: ${{ !(startsWith(matrix.os, 'macos') && matrix.python-version >= 3.9) }}
       run: poetry install --no-dev -E tests

--- a/benchmark/models/marsh.py
+++ b/benchmark/models/marsh.py
@@ -4,6 +4,7 @@ import dataclasses
 import datetime
 from typing import Optional, List
 
+import marshmallow
 from marshmallow import fields, Schema, validate as mvalidate, ValidationError
 
 
@@ -81,8 +82,10 @@ def initialize(**data):
 
 def validate(data):
     try:
-        result = SCHEMA.load(data)
-        return True, initialize(**result)
+        result: marshmallow.UnmarshalResult = SCHEMA.load(data)
+        if result.errors:
+            return False, result.errors
+        return True, initialize(**result.data)
 
     except ValidationError as err:
         return False, err.messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "typical"
 packages = [{include = "typic"}]
-version = "2.6.4"
+version = "2.7.0"
 description = "Typical: Python's Typing Toolkit."
 authors = ["Sean Stewart <sean_stewart@me.com>"]
 license = "MIT"

--- a/tests/objects.py
+++ b/tests/objects.py
@@ -4,6 +4,7 @@ import collections
 import dataclasses
 import datetime
 import enum
+import numbers
 import typing
 
 try:
@@ -444,6 +445,11 @@ def pep585(data: dict[str, int]) -> dict[str, int]:
 @typic.al
 def pep604(union: DFoo | DBar) -> DFoo | DBar:
     return union
+
+
+@typic.al
+def number(n: numbers.Number) -> numbers.Number:
+    return n
 
 
 TYPIC_OBJECTS = [

--- a/tests/objects.py
+++ b/tests/objects.py
@@ -267,6 +267,11 @@ class LargeInt(int):
     ...
 
 
+@typic.constrained(gt=1000)
+class LargeFloat(float):
+    ...
+
+
 @typic.constrained(values=LargeInt, keys=ShortStr)
 class LargeIntDict(dict):
     ...

--- a/tests/test_bind.py
+++ b/tests/test_bind.py
@@ -27,8 +27,63 @@ def kwarg(arg, **kwargs):  # pragma: nocover
     pass
 
 
-def typed(arg: str):  # pragma: nocover
-    return type(arg)
+def test_typed_arg():
+    def func(arg: str):
+        return arg
+
+    assert typic.bind(func, 1).eval() == typic.bind(func, arg=1).eval() == "1"
+
+
+def test_typed_arg_varg():
+    def func(arg: str, *args: int):
+        return arg, args
+
+    assert typic.bind(func, 1).eval() == typic.bind(func, arg=1).eval() == ("1", ())
+    assert typic.bind(func, 1, "1").eval() == ("1", (1,))
+
+
+def test_typed_arg_varg_kwarg():
+    def func(arg: str, *args: int, **kwargs: str):
+        return arg, args, kwargs
+
+    assert typic.bind(func, 1).eval() == typic.bind(func, arg=1).eval() == ("1", (), {})
+    assert typic.bind(func, 1, "1").eval() == ("1", (1,), {})
+    assert typic.bind(func, 1, "1", k=1).eval() == ("1", (1,), {"k": "1"})
+
+
+def test_typed_varg():
+    def func(*args: str):
+        return args
+
+    assert typic.bind(func).eval() == ()
+    assert typic.bind(func, 1).eval() == ("1",)
+
+
+def test_typed_kwarg():
+    def func(**kwargs: str):
+        return kwargs
+
+    assert typic.bind(func).eval() == {}
+    assert typic.bind(func, k=1).eval() == {"k": "1"}
+
+
+def test_typed_arg_kwarg():
+    def func(arg: str, **kwargs: str):
+        return arg, kwargs
+
+    assert typic.bind(func, 1).eval() == typic.bind(func, arg=1).eval() == ("1", {})
+    assert (
+        typic.bind(func, 1, k=1).eval()
+        == typic.bind(func, k=1, arg=1).eval()
+        == ("1", {"k": "1"})
+    )
+
+
+def test_typed_args_kwd():
+    def func(*args: int, kwd: str):
+        return args, kwd
+
+    assert typic.bind(func, "1", kwd=1).eval() == ((1,), "1")
 
 
 def test_bind():
@@ -38,12 +93,6 @@ def test_bind():
     baked = typic.bind(foo, *args, **kwargs)
     assert builtin.kwargs == baked.kwargs
     assert builtin.args == baked.args
-    assert dict(builtin.arguments) == baked.arguments
-
-
-def test_typed_no_coerce():
-    bound = typic.bind(typed, 1, coerce=False)
-    assert bound.arguments["arg"] == 1
 
 
 @pytest.mark.parametrize(
@@ -60,4 +109,4 @@ def test_typed_no_coerce():
 def test_bind_errors(func, params):
     args, kwargs = params
     with pytest.raises(TypeError):
-        typic.bind(func, *args, **kwargs)
+        typic.bind(func, *args, **kwargs).eval()

--- a/tests/test_serdes.py
+++ b/tests/test_serdes.py
@@ -489,6 +489,14 @@ def test_klass_iterate_exclude():
     assert dict(Foo().iterate()) == {"bar": None}
 
 
+@pytest.mark.parametrize(
+    argnames="v", argvalues=[1, objects.LargeInt(1001), 1.0, objects.LargeFloat(1000.5)]
+)
+def test_iterate_invalid(v):
+    with pytest.raises(TypeError):
+        typic.iterate(v)
+
+
 def test_transmute_excluded():
     @dataclasses.dataclass
     class Foo:

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -58,6 +58,7 @@ def test_isbuiltintype(obj: typing.Any):
     argnames=("annotation", "value", "expected"),
     argvalues=[
         (dict, [("foo", "bar")], {"foo": "bar"}),
+        (dict, [1], {0: 1}),
         (typing.Dict, [("foo", "bar")], {"foo": "bar"}),
         (list, set(), []),
         (typing.List, set(), []),

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -433,7 +433,11 @@ def test_transmute_nested_sequence():
 
 @pytest.mark.parametrize(
     argnames=("func", "input", "type"),
-    argvalues=[(objects.func, "1", int), (objects.Method().math, "4", int)],
+    argvalues=[
+        (objects.func, "1", int),
+        (objects.Method().math, "4", int),
+        (objects.number, 1, int),
+    ],
 )
 def test_wrap_callable(func, input, type):
     wrapped = wrap(func)

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -1067,17 +1067,41 @@ def test_tagged_union_validate(annotation, value):
 
 
 @pytest.mark.parametrize(
-    argnames="annotation,value,expected",
+    argnames="annotation,value,expected,t",
     argvalues=[
-        (typing.Union[int, str], "1", 1),
-        (typing.Union[int, str], "foo", "foo"),
-        (typing.Union[int, datetime.date], "1", 1),
-        (typing.Union[int, datetime.date], "1970-01-01", datetime.date(1970, 1, 1)),
+        (typing.Union[int, str], "1", 1, int),
+        (typing.Union[int, str], "foo", "foo", str),
+        (typing.Union[int, datetime.date], "1", 1, int),
+        (
+            typing.Union[int, datetime.date],
+            "1970-01-01",
+            datetime.date(1970, 1, 1),
+            datetime.date,
+        ),
+        (
+            typing.Union[objects.LargeFloat, objects.LargeInt],
+            "1001",
+            1001,
+            objects.LargeInt,
+        ),
+        (
+            typing.Union[objects.LargeFloat, objects.LargeInt],
+            "1001.0",
+            1001.0,
+            objects.LargeFloat,
+        ),
+        (
+            typing.Union[objects.LargeFloat, objects.LargeInt],
+            1001.0,
+            1001.0,
+            objects.LargeFloat,
+        ),
     ],
 )
-def test_union_transmute(annotation, value, expected):
+def test_union_transmute(annotation, value, expected, t):
     transmuted = transmute(annotation, value)
     assert transmuted == expected
+    assert isinstance(transmuted, t)
 
 
 @pytest.mark.parametrize(

--- a/typic/__init__.py
+++ b/typic/__init__.py
@@ -13,4 +13,4 @@ from .api import *
 al = typed
 
 
-__version__ = "2.6.4"
+__version__ = "2.7.0"

--- a/typic/api.py
+++ b/typic/api.py
@@ -4,6 +4,8 @@ import collections
 import dataclasses
 import functools
 import inspect
+import types
+import warnings
 from types import FunctionType, MethodType
 from typing import (
     Union,
@@ -19,11 +21,12 @@ from typing import (
     Dict,
     Set,
     List,
+    overload,
 )
 
 import typic.constraints as c
-from typic.checks import issubclass, isfrozendataclass
-from typic.compat import lru_cache
+from typic.checks import issubclass, isfrozendataclass, isbuiltintype
+from typic.compat import lru_cache, Generic
 from typic.env import Environ, EnvironmentTypeError, EnvironmentValueError
 from typic.serde.binder import BoundArguments
 from typic.serde.common import (
@@ -57,7 +60,7 @@ from typic.strict import (
     StrictModeT,
 )
 from typic.ext.schema import SchemaFieldT, builder as schema_builder, ObjectSchemaField
-from typic.util import origin, cached_type_hints
+from typic.util import origin, cached_type_hints, cached_signature
 from typic.types import FrozenDict, freeze
 
 __all__ = (
@@ -103,9 +106,9 @@ __all__ = (
     "WriteOnly",
 )
 
-ObjectT = TypeVar("ObjectT")
+ObjectT = TypeVar("ObjectT", bound=object)
 SchemaGenT = Callable[[Type[ObjectT]], SchemaFieldT]
-_TO_RESOLVE: Set[Union[Type["WrappedObjectT"], Callable]] = set()
+_TO_RESOLVE: Set[Union[Type[WrappedObjectT], Callable]] = set()
 
 
 transmute = resolver.transmute
@@ -129,30 +132,33 @@ annotations = resolver.protocols
 
 
 _T = TypeVar("_T")
+_Callable = TypeVar("_Callable", bound=Callable[..., Any])
+_Func = TypeVar("_Func", bound=types.FunctionType)
+_Type = TypeVar("_Type", bound=type)
 
 
-class TypicObjectT:
-    __serde__: SerdeProtocol
+class TypicObjectT(Generic[_T]):
+    __serde__: SerdeProtocol[Type[_T]]
     __serde_flags__: SerdeFlags
     __serde_protocols__: SerdeProtocolsT
-    __setattr_original__: Callable[["WrappedObjectT", str, Any], None]
+    __setattr_original__: Callable[[_T, str, Any], None]
     __typic_resolved__: bool
-    __iter__: FieldIteratorT
+    __iter__: FieldIteratorT[_T]
     schema: SchemaGenT
-    primitive: SerializerT
-    transmute: DeserializerT
-    translate: TranslatorT
-    validate: "c.ValidatorT"
+    primitive: SerializerT[_T]
+    transmute: DeserializerT[_T]
+    translate: TranslatorT[_T]
+    validate: c.ValidatorT[_T]
     tojson: Callable[..., str]
-    iterate: FieldIteratorT
+    iterate: FieldIteratorT[_T]
 
 
-WrappedObjectT = Union[TypicObjectT, ObjectT]
+WrappedObjectT = Union[TypicObjectT[_T], _T]
 
 
 def wrap(
-    func: Callable[..., _T], *, delay: bool = False, strict: StrictModeT = STRICT_MODE
-) -> Callable[..., _T]:
+    func: _Callable, *, delay: bool = None, strict: StrictModeT = STRICT_MODE
+) -> _Callable:
     """Wrap a callable to automatically enforce type-coercion.
 
     Parameters
@@ -169,17 +175,22 @@ def wrap(
     :py:func:`inspect.signature`
     :py:meth:`inspect.Signature.bind`
     """
-    if not delay:
-        protocols(func)
-    else:
-        _TO_RESOLVE.add(func)
+    if isinstance(delay, bool):
+        warnings.warn(
+            "The `delay` argument is no longer required and is deprecated. "
+            "It will be removed in a future version.",
+            category=DeprecationWarning,
+        )
+    protos = protocols(func, strict=cast(bool, strict))
+    params = cached_signature(func).parameters
+    enforcer = resolver.binder.get_enforcer(parameters=params, protocols=protos)
 
     @functools.wraps(func)
-    def func_wrapper(*args, **kwargs) -> _T:
-        bound = bind(func, *args, strict=strict, **kwargs)
-        return bound.eval()
+    def func_wrapper(*args, **kwargs):
+        args, kwargs = enforcer(*args, **kwargs)
+        return func(*args, **kwargs)
 
-    return func_wrapper
+    return cast(_Callable, func_wrapper)
 
 
 def _bind_proto(cls, proto: SerdeProtocol):
@@ -206,7 +217,7 @@ def _resolve_class(
     always: bool = True,
     jsonschema: bool = True,
     serde: SerdeFlags = None,
-) -> Type[WrappedObjectT]:
+) -> Type[WrappedObjectT[ObjectT]]:
     # Build the namespace for the new class
     strict = cast(bool, strict)
     protos = protocols(cls, strict=strict)
@@ -222,12 +233,13 @@ def _resolve_class(
         ns["schema"] = classmethod(schema)
         schema_builder.attach(cls)
 
-    # Frozen dataclasses don't use the native setattr
-    # So we wrap the init. This should be fine,
-    # just slower :(
-    if isfrozendataclass(cls):
+    # Wrap the init if
+    #   a) this is a "frozen" dataclass
+    #   b) we only want to coerce on init.
+    # N.B.: Frozen dataclasses don't use the native setattr and can't be updated.
+    if isfrozendataclass(cls) or not always:
         ns["__init__"] = wrap(cls.__init__, strict=strict)
-    # The faster way - create a new setattr that applies the protocol for a given attr
+    # For 'always', create a new setattr that applies the protocol for a given attr
     else:
         trans = freeze({x: y.transmute for x, y in protos.items()})
 
@@ -257,7 +269,7 @@ def _resolve_class(
     _bind_proto(cls, proto)
     # Track resolution state.
     setattr(cls, "__typic_resolved__", True)
-    return cls
+    return cast(Type[WrappedObjectT[ObjectT]], cls)
 
 
 def _delay_resolve_class(
@@ -304,7 +316,7 @@ def wrap_cls(
     strict: StrictModeT = STRICT_MODE,
     jsonschema: bool = True,
     serde: SerdeFlags = SerdeFlags(),
-) -> Type[WrappedObjectT]:
+) -> Type[WrappedObjectT[ObjectT]]:
     """Wrap a class to automatically enforce type-coercion on init.
 
     Notes
@@ -328,17 +340,17 @@ def wrap_cls(
         Optional settings for serialization/deserialization
     """
 
-    def cls_wrapper(cls_: Type[ObjectT]) -> Type[WrappedObjectT]:
+    def cls_wrapper(cls_: Type[ObjectT]) -> Type[WrappedObjectT[ObjectT]]:
         setattr(cls_, "__delayed__", delay)
         if delay:
             _delay_resolve_class(
                 cls_, strict=strict, jsonschema=jsonschema, serde=serde
             )
-            return cast(Type[WrappedObjectT], cls_)
+            return cast(Type[TypicObjectT[ObjectT]], cls_)
 
         return _resolve_class(cls_, strict=strict, jsonschema=jsonschema, serde=serde)
 
-    wrapped: Type[WrappedObjectT] = cls_wrapper(klass)
+    wrapped: Type[WrappedObjectT[ObjectT]] = cls_wrapper(klass)
     return wrapped
 
 
@@ -354,6 +366,27 @@ def _get_setter(cls: Type, bases: Tuple[Type, ...] = None):
             if setter.__name__ != "__setattr_coerced__":
                 break
     return setter
+
+
+@overload
+def typed(
+    _cls_or_callable: _Type, *, delay: bool = False, strict: bool = None
+) -> Type[WrappedObjectT[_Type]]:
+    ...
+
+
+@overload
+def typed(
+    _cls_or_callable: _Func, *, delay: bool = False, strict: bool = None
+) -> _Func:
+    ...
+
+
+@overload
+def typed(
+    *, delay: bool = False, strict: bool = None
+) -> Union[Callable[[_Type], Type[WrappedObjectT[_Type]]], Callable[[_Func], _Func]]:
+    ...
 
 
 def typed(_cls_or_callable=None, *, delay: bool = False, strict: bool = None):
@@ -571,16 +604,21 @@ def constrained(
 
             return __constrained_init
 
+        name = cls_.__name__
+        if isbuiltintype(cls_):
+            name = f"Constrained{cls_.__name__.capitalize()}"
+
         cdict.update(
             __constraints__=constraints_inst,
             __parent__=constraints_inst.type,
+            __module__=cls_.__module__,
             **(
                 {"__new__": new(cls_.__new__)}
                 if constraints_inst.type in {str, bytes, int, float}
                 else {"__init__": init(cls_.__init__)}
             ),
         )
-        cls: Type[ObjectT] = cast(Type[ObjectT], type(cls_.__name__, bases, cdict))
+        cls: Type[ObjectT] = cast(Type[ObjectT], type(name, bases, cdict))
 
         return cls
 

--- a/typic/checks.py
+++ b/typic/checks.py
@@ -609,7 +609,7 @@ def isfrozendataclass(obj: Type[ObjectT]) -> TypeGuard[_FrozenDataclass]:
 
 
 class _FrozenDataclass(Protocol):
-    __dataclas_params__: dataclasses._DataclassParams  # type: ignore
+    __dataclass_params__: dataclasses._DataclassParams  # type: ignore
 
 
 _isinstance = isinstance

--- a/typic/checks.py
+++ b/typic/checks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import abc
 import builtins
 import dataclasses
 import datetime
@@ -7,6 +8,7 @@ import decimal
 import enum
 import inspect
 import ipaddress
+import numbers
 import pathlib
 import types
 import uuid
@@ -62,6 +64,7 @@ str
 __all__ = (
     "BUILTIN_TYPES",
     "ObjectT",
+    "isabstract",
     "isbuiltininstance",
     "isbuiltintype",
     "isbuiltinsubtype",
@@ -825,3 +828,11 @@ _ATTR_CHECKS = (inspect.isclass, inspect.isroutine, isproperty)
 
 def issimpleattribute(v) -> bool:
     return not any(c(v) for c in _ATTR_CHECKS)
+
+
+def isabstract(o) -> TypeGuard[abc.ABC]:
+    return inspect.isabstract(o) or o in _ABCS
+
+
+# Custom list of ABCs which incorrectly evaluate to false
+_ABCS = frozenset({numbers.Number})

--- a/typic/compat.py
+++ b/typic/compat.py
@@ -13,9 +13,9 @@ from typing import (
 )
 
 try:
-    from typing import Final, TypedDict, Literal, Protocol, TypeGuard, get_origin, get_args  # type: ignore
+    from typing import Final, TypedDict, Literal, Protocol, Generic, TypeGuard, get_origin, get_args  # type: ignore
 except ImportError:  # pragma: nocover
-    from typing_extensions import Final, TypedDict, Literal, Protocol, TypeGuard, get_origin, get_args  # type: ignore
+    from typing_extensions import Final, TypedDict, Literal, Protocol, Generic, TypeGuard, get_origin, get_args  # type: ignore
 try:
     from typing import ForwardRef  # type: ignore
 except ImportError:  # pragma: nocover

--- a/typic/constraints/factory.py
+++ b/typic/constraints/factory.py
@@ -38,6 +38,7 @@ from typic.checks import (
     should_unwrap,
     isclassvartype,
     isenumtype,
+    isabstract,
 )
 from typic.compat import Literal, lru_cache
 from typic.types import dsn, email, frozendict, path, secret, url
@@ -121,6 +122,10 @@ def get_constraints(
     if isenumtype(t):
         ec = _from_enum_type(t, nullable=nullable, name=name)  # type: ignore
         return cast(ConstraintsProtocolT, ec)
+    if isabstract(t):
+        return cast(
+            ConstraintsProtocolT, _from_strict_type(t, nullable=nullable, name=name)
+        )
     if isnamedtuple(t) or istypeddict(t):
         handler = _from_class
     else:

--- a/typic/ext/schema/schema.py
+++ b/typic/ext/schema/schema.py
@@ -392,7 +392,8 @@ class SchemaBuilder:
             defname = name
         return inflection.camelize(defname) if defname else None
 
-    _IGNORE_NAME = {"Mapping", "MutableMapping", "Dict"}
+    # FIXME: This isn't sustainable. Figure out a better way to ignore generics.
+    _IGNORE_NAME = {"Mapping", "MutableMapping", "Dict", "Literal"}
 
     def build_schema(self, obj: Type, *, name: str = None) -> ObjectSchemaField:
         """Build a valid JSON Schema, including nested schemas."""

--- a/typic/serde/resolver.py
+++ b/typic/serde/resolver.py
@@ -514,6 +514,43 @@ class Resolver:
         )
         return anno
 
+    @staticmethod
+    def _finalize_deserializer(
+        annotation: Annotation[Type[ObjectT]],
+        deserializer: DeserializerT[ObjectT],
+        constraints: constr.ConstraintsProtocolT[ObjectT],
+    ) -> Tuple[DeserializerT[ObjectT], constr.ValidateT[ObjectT]]:
+        # Set the default returns.
+        validator = constraints.validate
+        rdeserializer = deserializer
+        # If we're in "strict" mode, we want to default to only validation.
+        if annotation.strict:
+            rdeserializer = cast(DeserializerT[ObjectT], validator)
+
+        # If we have type constraints, we'll bail out early.
+        # If we have literal constraints, we must validate as a part of coercion.
+        if isinstance(constraints, (constr.TypeConstraints, constr.LiteralConstraints)):
+            if isinstance(constraints, constr.LiteralConstraints):
+                d = deserializer
+
+                def des(val: Any, *, __d=d, __v=validator) -> ObjectT:
+                    return __v(__d(val))
+
+                rdeserializer = cast(DeserializerT[ObjectT], des)
+
+            return rdeserializer, validator
+        # Finally, if we're in "strict" mode, but the constraint needs validation prior
+        #   to coercion, we should inject the validator within the deserializer.
+        if annotation.strict and constraints.coerce:
+            d = deserializer
+
+            def des(val: Any, *, __d=d, __v=validator) -> ObjectT:
+                return __d(__v(val))
+
+            rdeserializer = cast(DeserializerT[ObjectT], des)
+
+        return rdeserializer, validator
+
     def _resolve_from_annotation(
         self,
         anno: Annotation[Type[ObjectT]],
@@ -529,8 +566,9 @@ class Resolver:
         constraints = constr.get_constraints(
             anno.resolved, nullable=anno.optional, cls=namespace
         )
-        deserializer, validator = self.des.factory(
-            anno, constraints, namespace=namespace
+        deserializer = self.des.factory(anno, namespace=namespace)
+        deserializer, validator = self._finalize_deserializer(
+            annotation=anno, deserializer=deserializer, constraints=constraints
         )
         # Build the serializer
         serializer = self.ser.factory(anno)

--- a/typic/serde/resolver.py
+++ b/typic/serde/resolver.py
@@ -524,7 +524,7 @@ class Resolver:
         validator = constraints.validate
         rdeserializer = deserializer
         # If we're in "strict" mode, we want to default to only validation.
-        if annotation.strict:
+        if annotation.strict or checks.isabstract(annotation.resolved_origin):
             rdeserializer = cast(DeserializerT[ObjectT], validator)
 
         # If we have type constraints, we'll bail out early.

--- a/typic/util.py
+++ b/typic/util.py
@@ -252,10 +252,13 @@ def get_qualname(obj: Union[Type, ForwardRef, Callable]) -> str:
     'dict'
     """
     strobj = str(obj)
-    isgeneric = strobj.startswith("typing.")
-    if not isgeneric and isinstance(obj, ForwardRef):
+    if isinstance(obj, ForwardRef):
         strobj = str(obj.__forward_arg__)
-        isgeneric = strobj.startswith("typing.")
+    isgeneric = (
+        strobj.startswith("typing.")
+        or strobj.startswith("typing_extensions.")
+        or "[" in strobj
+    )
     # We got a typing thing.
     if isgeneric:
         # If this is a subscripted generic we should clean that up.


### PR DESCRIPTION
## Optimizations

This change introduces an overhauled evaluation of callable signatures which now provides comparable performance to our serdes protocol bindings.

```python

import dataclasses
import timeit
import typic


@dataclasses.dataclass
class Foo:
    bar: str


@dataclasses.dataclass(frozen=True)
class Froze:
    bar: str


foo_proto = typic.protocol(Foo)
froze_proto = typic.protocol(Froze)

print(timeit.timeit('foo_proto.transmute({"bar": 1})', globals=globals()))
#> 2.1221675970000007
print(timeit.timeit('froze_proto.transmute({"bar": 1})', globals=globals()))
#> 2.264840293000006
```

The previous implementation was up to 10X slower.

## Improvements

More descriptive type-hints for our api module to aid IDE and MyPy.

## Fixes 

Resolves the issues mentioned in #170 & #174